### PR TITLE
fix query params, explicit 400

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.0.0-beta",
+  "version": "3.0.0-beta1",
   "main": "dist/index.js",
   "module": "src/index.js",
   "files": [

--- a/src/http.js
+++ b/src/http.js
@@ -13,11 +13,11 @@ export function request(method, path, data, callback) {
   if (method === 'GET') {
     const qsArr = [];
     for (let key in data) {
-      qsArr.push(`${key}=${data[key]}`);
+      qsArr.push(`${key}=${encodeURIComponent(data[key])}`);
     }
 
     if (qsArr.length > 0) {
-      const qs = encodeURIComponent(qsArr.join('&'));
+      const qs = qsArr.join('&');
       url = `${url}?${qs}`;
     }
   } else {
@@ -44,9 +44,11 @@ export function request(method, path, data, callback) {
       } catch (e) {
         callback(STATUS.ERROR_SERVER);
       }
-    } else if (xhr.status == 401) {
+    } else if (xhr.status === 400) {
+      callback(STATUS.ERROR_PARAMETERS);
+    } else if (xhr.status === 401) {
       callback(STATUS.ERROR_UNAUTHORIZED);
-    } else if (xhr.status == 429) {
+    } else if (xhr.status === 429) {
       callback(STATUS.ERROR_RATE_LIMIT);
     } else {
       callback(STATUS.ERROR_SERVER);

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.0.0-beta';
+export default '3.0.0-beta1';

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -43,6 +43,18 @@ describe('http', () => {
       expect(httpCallback).to.have.been.calledWith(STATUS.SUCCESS, { success: true });
     });
 
+    it('should respond with a 400', () => {
+      getCookieStub.withArgs(Cookie.PUBLISHABLE_KEY).returns(publishableKey);
+
+      const httpCallback = sinon.spy();
+      Http.request('PUT', 'v1/users/userId', {}, httpCallback);
+
+      expect(request).to.not.be.null;
+      request.respond(400);
+
+      expect(httpCallback).to.be.calledWith(STATUS.ERROR_PARAMETERS);
+    });
+
     it('should respond with unauthorized status', () => {
       getCookieStub.withArgs(Cookie.PUBLISHABLE_KEY).returns(publishableKey);
 
@@ -143,7 +155,7 @@ describe('http', () => {
 
       expect(httpCallback).to.be.calledWith(STATUS.SUCCESS, JSON.parse(getResponse));
 
-      const urlencodedData = encodeURIComponent(`query=${data.query}`);
+      const urlencodedData = `query=${encodeURIComponent(data.query)}`;
       expect(request.url).to.contain(`?${urlencodedData}`);
     });
 


### PR DESCRIPTION
https://app.clubhouse.io/radarlabs/story/2116/radar-sdk-js-3-0-0-beta1

incorrectly encoding `=` and `&`:
![Screen Shot 2020-04-08 at 1 03 53 PM](https://user-images.githubusercontent.com/58698757/78812439-6d5d2700-7999-11ea-8d3e-647489d2c963.png)
