### PR TITLE
response available on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The SDK uses the [HTML5 geolocation API](https://developer.mozilla.org/en-US/doc
 To track the user's location, call:
 
 ```javascript
-Radar.trackOnce(function(err, { location, user, events }) {
+Radar.trackOnce(function(err, { status, location, user, events }) {
   if (!err) {
     // do something with location, user, events
   }

--- a/demo/test.html
+++ b/demo/test.html
@@ -101,7 +101,7 @@
 
         Radar.initialize(publishableKey);
 
-        Radar.trackOnce(function(err, { status, location, user, events, response }) {
+        Radar.trackOnce(function(err, { status, location, user, events }, response) {
 
           console.log({ err, location, user, events, response });
 

--- a/demo/test.html
+++ b/demo/test.html
@@ -101,8 +101,9 @@
 
         Radar.initialize(publishableKey);
 
-        Radar.trackOnce(function(err, { location, user, events, response }) {
-          console.log(err, location, user, events);
+        Radar.trackOnce(function(err, { status, location, user, events, response }) {
+
+          console.log({ err, location, user, events, response });
 
           $('input,button').prop('disabled', false);
           $('.loader').addClass('d-none');
@@ -114,7 +115,7 @@
             return;
           }
 
-          $('#status').html(formatCode(response.meta));
+          $('#status').html(status);
 
           $('#location').html(formatCode({
             accuracy: location.accuracy,

--- a/src/http.js
+++ b/src/http.js
@@ -50,28 +50,39 @@ class Http {
       xhr.setRequestHeader('X-Radar-SDK-Version', SDK_VERSION);
 
       xhr.onload = () => {
-        if (xhr.status == 200) {
-          try {
-            resolve(JSON.parse(xhr.response));
-          } catch (e) {
-            reject(STATUS.ERROR_SERVER);
-          }
-        } else if (xhr.status === 400) {
-          reject(STATUS.ERROR_BAD_REQUEST);
-        } else if (xhr.status === 401) {
-          reject(STATUS.ERROR_UNAUTHORIZED);
-        } else if (xhr.status === 402) {
-          reject(STATUS.ERROR_PAYMENT_REQUIRED);
-        } else if (xhr.status === 403) {
-          reject(STATUS.ERROR_FORBIDDEN);
-        } else if (xhr.status === 404) {
-          reject(STATUS.ERROR_NOT_FOUND);
-        } else if (xhr.status === 429) {
-          reject(STATUS.ERROR_RATE_LIMIT);
-        } else if (500 <= xhr.status && xhr.status < 600) {
+        let response;
+        try {
+          response = JSON.parse(xhr.response);
+        } catch (e) {
           reject(STATUS.ERROR_SERVER);
+        }
+
+        if (xhr.status == 200) {
+          resolve(response);
+
+        } else if (xhr.status === 400) {
+          reject({ httpError: STATUS.ERROR_BAD_REQUEST, response });
+
+        } else if (xhr.status === 401) {
+          reject({ httpError: STATUS.ERROR_UNAUTHORIZED, response });
+
+        } else if (xhr.status === 402) {
+          reject({ httpError: STATUS.ERROR_PAYMENT_REQUIRED, response });
+
+        } else if (xhr.status === 403) {
+          reject({ httpError: STATUS.ERROR_FORBIDDEN, response });
+
+        } else if (xhr.status === 404) {
+          reject({ httpError: STATUS.ERROR_NOT_FOUND, response });
+
+        } else if (xhr.status === 429) {
+          reject({ httpError: STATUS.ERROR_RATE_LIMIT, response });
+
+        } else if (500 <= xhr.status && xhr.status < 600) {
+          reject({ httpError: STATUS.ERROR_SERVER, response });
+
         } else {
-          reject(STATUS.ERROR_UNKNOWN);
+          reject({ httpError: STATUS.ERROR_UNKNOWN, response });
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const handleError = (callback) => {
 
     // Http Error
     if (typeof err === 'object' && err.httpError) {
-      callback(err.httpError, { response: err.response });
+      callback(err.httpError, {}, err.response);
       return;
     }
 
@@ -116,8 +116,7 @@ class Radar {
           user: response.user,
           events: response.events,
           status: STATUS.SUCCESS,
-          response,
-        });
+        }, response);
       })
       .catch(handleError(callback));
   }
@@ -147,7 +146,7 @@ class Radar {
 
     Context.getContext(location)
       .then((response) => {
-        callback(null, { context: response.context, status: STATUS.SUCCESS, response });
+        callback(null, { context: response.context, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -159,7 +158,7 @@ class Radar {
 
     Search.searchPlaces(searchOptions)
       .then((response) => {
-        callback(null, { places: response.places, status: STATUS.SUCCESS, response });
+        callback(null, { places: response.places, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -171,7 +170,7 @@ class Radar {
 
     Search.searchGeofences(searchOptions)
       .then((response) => {
-        callback(null, { geofences: response.geofences, status: STATUS.SUCCESS, response });
+        callback(null, { geofences: response.geofences, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -183,7 +182,7 @@ class Radar {
 
     Search.autocomplete(searchOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS, response });
+        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -195,7 +194,7 @@ class Radar {
 
     Geocoding.geocode(geocodeOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, staus: STATUS.SUCCESS, response });
+        callback(null, { addresses: response.addresses, staus: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -225,7 +224,7 @@ class Radar {
 
     Geocoding.reverseGeocode(geocodeOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS, response });
+        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -237,7 +236,7 @@ class Radar {
 
     Geocoding.ipGeocode()
       .then((response) => {
-        callback(null, { address: response.address, status: STATUS.SUCCESS, response });
+        callback(null, { address: response.address, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }
@@ -249,7 +248,7 @@ class Radar {
 
     Routing.getDistanceToDestination(routingOptions)
       .then((response) => {
-        callback(null, { routes: response.routes, status: STATUS.SUCCESS, response });
+        callback(null, { routes: response.routes, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,26 @@ import Track from './api/track';
 import SDK_VERSION from './version';
 import STATUS from './status';
 
+const handleError = (callback) => {
+  return (err) => {
+
+    // Radar Error
+    if (typeof err === 'string') {
+      callback(err, {});
+      return;
+    }
+
+    // Http Error
+    if (typeof err === 'object' && err.httpError) {
+      callback(err.httpError, { response: err.response });
+      return;
+    }
+
+    // Unknown
+    callback(STATUS.ERROR_UNKNOWN, {});
+  };
+};
+
 class Radar {
   static get VERSION() {
     return SDK_VERSION;
@@ -68,7 +88,7 @@ class Radar {
       .then((location) => {
         callback(null, { location, status: STATUS.SUCCESS });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static trackOnce(arg0, arg1) {
@@ -96,9 +116,10 @@ class Radar {
           user: response.user,
           events: response.events,
           status: STATUS.SUCCESS,
-        }, response);
+          response,
+        });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static getContext(arg0, arg1) {
@@ -126,9 +147,9 @@ class Radar {
 
     Context.getContext(location)
       .then((response) => {
-        callback(null, { context: response.context, status: STATUS.SUCCESS }, response);
+        callback(null, { context: response.context, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static searchPlaces(searchOptions, callback) {
@@ -138,9 +159,9 @@ class Radar {
 
     Search.searchPlaces(searchOptions)
       .then((response) => {
-        callback(null, { places: response.places, status: STATUS.SUCCESS }, response);
+        callback(null, { places: response.places, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static searchGeofences(searchOptions, callback) {
@@ -150,9 +171,9 @@ class Radar {
 
     Search.searchGeofences(searchOptions)
       .then((response) => {
-        callback(null, { geofences: response.geofences, status: STATUS.SUCCESS }, response);
+        callback(null, { geofences: response.geofences, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static autocomplete(searchOptions, callback) {
@@ -162,9 +183,9 @@ class Radar {
 
     Search.autocomplete(searchOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS }, response);
+        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static geocode(geocodeOptions, callback) {
@@ -174,9 +195,9 @@ class Radar {
 
     Geocoding.geocode(geocodeOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, staus: STATUS.SUCCESS }, response);
+        callback(null, { addresses: response.addresses, staus: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static reverseGeocode(arg0, arg1) {
@@ -204,9 +225,9 @@ class Radar {
 
     Geocoding.reverseGeocode(geocodeOptions)
       .then((response) => {
-        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS }, response);
+        callback(null, { addresses: response.addresses, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static ipGeocode(callback) {
@@ -216,9 +237,9 @@ class Radar {
 
     Geocoding.ipGeocode()
       .then((response) => {
-        callback(null, { address: response.address, status: STATUS.SUCCESS }, response);
+        callback(null, { address: response.address, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 
   static getDistance(routingOptions, callback) {
@@ -228,9 +249,9 @@ class Radar {
 
     Routing.getDistanceToDestination(routingOptions)
       .then((response) => {
-        callback(null, { routes: response.routes, status: STATUS.SUCCESS }, response);
+        callback(null, { routes: response.routes, status: STATUS.SUCCESS, response });
       })
-      .catch(callback);
+      .catch(handleError(callback));
   }
 }
 

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -84,7 +84,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_BAD_REQUEST);
+          expect(e.httpError).to.equal(STATUS.ERROR_BAD_REQUEST);
         }
       });
 
@@ -96,7 +96,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_BAD_REQUEST);
+          expect(e.httpError).to.equal(STATUS.ERROR_BAD_REQUEST);
         }
       });
 
@@ -108,7 +108,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_UNAUTHORIZED);
+          expect(e.httpError).to.equal(STATUS.ERROR_UNAUTHORIZED);
         }
       });
 
@@ -120,7 +120,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_PAYMENT_REQUIRED);
+          expect(e.httpError).to.equal(STATUS.ERROR_PAYMENT_REQUIRED);
         }
       });
 
@@ -132,7 +132,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_FORBIDDEN);
+          expect(e.httpError).to.equal(STATUS.ERROR_FORBIDDEN);
         }
       });
 
@@ -144,7 +144,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_NOT_FOUND);
+          expect(e.httpError).to.equal(STATUS.ERROR_NOT_FOUND);
         }
       });
 
@@ -156,7 +156,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_RATE_LIMIT);
+          expect(e.httpError).to.equal(STATUS.ERROR_RATE_LIMIT);
         }
       });
 
@@ -168,7 +168,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_SERVER);
+          expect(e.httpError).to.equal(STATUS.ERROR_SERVER);
         }
       });
 
@@ -180,7 +180,7 @@ describe('Http', () => {
         try {
           await httpRequest;
         } catch (e) {
-          expect(e).to.equal(STATUS.ERROR_UNKNOWN);
+          expect(e.httpError).to.equal(STATUS.ERROR_UNKNOWN);
         }
       });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -207,7 +207,7 @@ describe('Radar', () => {
       });
     });
 
-    describe('Unkown', () => {
+    describe('Unknown', () => {
       it('should return the unknown error and empty object', (done) => {
         trackStub.returns(Promise.reject({ error: 'invalid error' }));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -171,6 +171,55 @@ describe('Radar', () => {
     });
   });
 
+  context('api errors', () => {
+      let trackStub;
+
+      beforeEach(() => {
+        trackStub = sinon.stub(Track, 'trackOnce');
+      });
+
+      afterEach(() => {
+        Track.trackOnce.restore();
+      });
+
+    describe('Radar error', (done) => {
+      it('should return the error enum and empty object', () => {
+        trackStub.returns(Promise.reject(STATUS.ERROR_LOCATION));
+
+        Radar.trackOnce((err, obj) => {
+          expect(err).to.equal(STATUS.ERROR_LOCATION);
+          expect(obj).to.deep.equal({});
+          done();
+        });
+      });
+    });
+
+    describe('Http Error', () => {
+      it('should return the error enum and response object', (done) => {
+        const response = { meta: { code: 400 } };
+        trackStub.returns(Promise.reject({ httpError: STATUS.ERROR_BAD_REQUEST, response }));
+
+        Radar.trackOnce((err, obj) => {
+          expect(err).to.equal(STATUS.ERROR_BAD_REQUEST);
+          expect(obj).to.deep.equal({ response });
+          done();
+        });
+      });
+    });
+
+    describe('Unkown', () => {
+      it('should return the unknown error and empty object', (done) => {
+        trackStub.returns(Promise.reject({ error: 'invalid error' }));
+
+        Radar.trackOnce((err, obj) => {
+          expect(err).to.equal(STATUS.ERROR_UNKNOWN);
+          expect(obj).to.deep.equal({});
+          done();
+        });
+      });
+    });
+  });
+
   context('getLocation', () => {
     let navigatorStub;
 
@@ -182,19 +231,21 @@ describe('Radar', () => {
       Navigator.getCurrentPosition.restore();
     });
 
-    it('should throw an error if no callback present', () => {
+    it('should throw an error if no callback present', (done) => {
       try {
         Radar.getLocation();
       } catch (e) {
         expect(e.message).to.equal('ERROR_MISSING_CALLBACK');
+        done();
       }
     });
 
-    it('should propagate the err if not successful', () => {
-      navigatorStub.rejects(STATUS.ERROR_LOCATION);
+    it('should propagate the err if not successful', (done) => {
+      navigatorStub.returns(Promise.reject(STATUS.ERROR_LOCATION));
 
       Radar.getLocation((err) => {
-        expect(err.toString()).to.equal(STATUS.ERROR_LOCATION);
+        expect(err).to.equal(STATUS.ERROR_LOCATION);
+        done();
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -182,8 +182,8 @@ describe('Radar', () => {
         Track.trackOnce.restore();
       });
 
-    describe('Radar error', (done) => {
-      it('should return the error enum and empty object', () => {
+    describe('Radar error', () => {
+      it('should return the error enum and empty object', (done) => {
         trackStub.returns(Promise.reject(STATUS.ERROR_LOCATION));
 
         Radar.trackOnce((err, obj) => {
@@ -199,9 +199,10 @@ describe('Radar', () => {
         const response = { meta: { code: 400 } };
         trackStub.returns(Promise.reject({ httpError: STATUS.ERROR_BAD_REQUEST, response }));
 
-        Radar.trackOnce((err, obj) => {
+        Radar.trackOnce((err, obj, res) => {
           expect(err).to.equal(STATUS.ERROR_BAD_REQUEST);
-          expect(obj).to.deep.equal({ response });
+          expect(obj).to.deep.equal({});
+          expect(res).to.deep.equal(response);
           done();
         });
       });


### PR DESCRIPTION
Made a few adjustments to make the success/error cases more consistent:
- [x] In the case of an error, the second arg will still be present as an empty object (this allows for destructuring in signature)
- [x] In the case of an http error, the response will still be present in the third arg
