### PR TITLE
remove module from package. make demo page IE 11 friendly

### DIFF
--- a/demo/test.html
+++ b/demo/test.html
@@ -101,9 +101,12 @@
 
         Radar.initialize(publishableKey);
 
-        Radar.trackOnce(function(err, { status, location, user, events }, response) {
+        Radar.trackOnce(function(err, responseObj, response) {
+          const location = responseObj.location;
+          const user = responseObj.user;
+          const events = responseObj.events;
 
-          console.log({ err, location, user, events, response });
+          console.log(err, location, user, events, response);
 
           $('input,button').prop('disabled', false);
           $('.loader').addClass('d-none');

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0-beta.6",
   "main": "dist/index.js",
-  "module": "src/index.js",
   "files": [
     "dist",
     "src",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.0.0-beta.5';
+export default '3.0.0-beta.6';


### PR DESCRIPTION
Since this doesn't have support for node, we don't need the `module` property set (should just use the `main` property).