### PR TITLE
cve serialize javascript and minimist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5113,8 +5113,8 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "resolved": false,
+      "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
       "dev": true
     },
     "mixin-deep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,7 +5112,7 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
+      "version": "0.2.1",
       "resolved": false,
       "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
       "dev": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,9 +5112,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "0.2.1",
+      "resolved": false,
+      "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
       "dev": true
     },
     "mixin-deep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,7 +5146,7 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.1"
       }
     },
     "mocha": {
@@ -5893,7 +5893,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.1"
           },
           "dependencies": {
             "minimist": {
@@ -5945,7 +5945,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "~0.0.1",
+            "minimist": "~0.2.1",
             "wordwrap": "~0.0.2"
           }
         },
@@ -7171,7 +7171,7 @@
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "jest-worker": "^23.2.0",
-        "serialize-javascript": "^1.5.0",
+        "serialize-javascript": "^2.1.1",
         "uglify-js": "^3.4.9"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,9 +5112,9 @@
       }
     },
     "minimist": {
-      "version": "0.2.1",
-      "resolved": false,
-      "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mixin-deep": {


### PR DESCRIPTION
- https://trello.com/c/v9lKpdN0/703-cve-serialize-javascript-radar-sdk-js
- it was passing in radar-sdk-js@3.0.0-beta.7 not in radar-sdk-js@3.0.0-beta.8
- Uglify has some code change requirements. Lack of backward compatibility