### PR TITLE
Add support for country param in geocode endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.1.0",
+  "version": "3.2.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.1.1",
+  "version": "3.2.0-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/geocoding.js
+++ b/src/api/geocoding.js
@@ -3,9 +3,9 @@ import Navigator from '../navigator';
 
 class Geocoding {
   static async geocode(geocodeOptions={}) {
-    const { query, layers } = geocodeOptions;
+    const { query, layers, country } = geocodeOptions;
 
-    return Http.request('GET', 'v1/geocode/forward', { query, layers });
+    return Http.request('GET', 'v1/geocode/forward', { query, layers, country });
   }
 
   static async reverseGeocode(geocodeOptions={}) {

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -88,6 +88,7 @@ class Search {
       near,
       limit,
       layers,
+      country,
     } = searchOptions;
 
     if (near?.latitude && near?.longitude) {
@@ -99,6 +100,7 @@ class Search {
       near,
       limit,
       layers,
+      country,
     };
 
     return Http.request('GET', 'v1/search/autocomplete', params);

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.1.1';
+export default '3.2.0-beta.1';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.2.0-beta.1';
+export default '3.2.0';

--- a/test/api/search.test.js
+++ b/test/api/search.test.js
@@ -24,6 +24,7 @@ describe('Search', () => {
   const tags = ['geofence-tag'];
   const metadata = {'geofence-metadata-key': 'geofence-metadata-value'};
   const layers = ['venue', 'address'];
+  const country = 'US';
   const limit = 50;
   const query = 'mock-query';
 
@@ -120,27 +121,27 @@ describe('Search', () => {
   });
 
   context('autocomplete', () => {
-    describe('near is not provided', () => {
-      it('should have near undefined and return an autocomplete response', () => {
+    describe('params are not provided', () => {
+      it('should have undefined params and return an autocomplete response', () => {
         httpStub.resolves(autocompleteResponse);
 
         return Search.autocomplete({ query })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined });
+            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined });
             expect(response).to.equal(autocompleteResponse);
           });
       });
     });
 
-    describe('near is provided', () => {
+    describe('params are provided', () => {
       it('should return an autocomplete response', () => {
         httpStub.resolves(autocompleteResponse);
 
         const near = { latitude, longitude };
 
-        return Search.autocomplete({ near, query, limit, layers })
+        return Search.autocomplete({ near, query, limit, layers, country })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'] });
+            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country });
             expect(response).to.equal(autocompleteResponse);
           });
       });


### PR DESCRIPTION
Adds support for `country` filter on geocode & autocomplete endpoint.

Docs: https://radar.com/documentation/api#query-parameters-1