### PR TITLE
Move to new convenience image for CircleCI. Bump revision.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.22.7
+      - image: cimg/node:12.22.12  # April 2022
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@latest'
+          command: 'npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:


### PR DESCRIPTION
Uses new CircleCI convenience images: https://circleci.com/developer/images?imageType=docker.

Bumps the node version (patch number only) to get a more recent image (April 2022). 