### PR TITLE
Use BASE_API_PATH for all endpoints in JS SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.4.0-beta",
+  "version": "3.5.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.4.0-beta",
+      "version": "3.5.0-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.4.0-beta",
+  "version": "3.5.0-beta",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/context.js
+++ b/src/api/context.js
@@ -13,7 +13,7 @@ class Context {
       coordinates: `${latitude},${longitude}`,
     };
 
-    return Http.request('GET', `v1/context`, params);
+    return Http.request('GET', `context`, params);
   }
 }
 

--- a/src/api/geocoding.js
+++ b/src/api/geocoding.js
@@ -5,7 +5,7 @@ class Geocoding {
   static async geocode(geocodeOptions={}) {
     const { query, layers, country } = geocodeOptions;
 
-    return Http.request('GET', 'v1/geocode/forward', { query, layers, country });
+    return Http.request('GET', 'geocode/forward', { query, layers, country });
   }
 
   static async reverseGeocode(geocodeOptions={}) {
@@ -22,13 +22,13 @@ class Geocoding {
       layers,
     };
 
-    return Http.request('GET', 'v1/geocode/reverse', params);
+    return Http.request('GET', 'geocode/reverse', params);
   }
 
   static async ipGeocode(geocodeOptions={}) {
     const { ip } = geocodeOptions;
 
-    return Http.request('GET', 'v1/geocode/ip', { ip });
+    return Http.request('GET', 'geocode/ip', { ip });
   }
 }
 

--- a/src/api/routing.js
+++ b/src/api/routing.js
@@ -33,7 +33,7 @@ class Routing {
       geometry,
     };
 
-    return Http.request('GET', 'v1/route/distance', params);
+    return Http.request('GET', 'route/distance', params);
   }
 
   static async getMatrixDistances(routingOptions={}) {
@@ -66,7 +66,7 @@ class Routing {
       geometry,
     };
 
-    return Http.request('GET', 'v1/route/matrix', params);
+    return Http.request('GET', 'route/matrix', params);
   }
 }
 

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -38,7 +38,7 @@ class Search {
       limit,
     };
 
-    return Http.request('GET', 'v1/search/places', params);
+    return Http.request('GET', 'search/places', params);
   }
 
   static async searchGeofences(searchOptions={}) {
@@ -76,7 +76,7 @@ class Search {
       });
     }
 
-    return Http.request('GET', 'v1/search/geofences', params);
+    return Http.request('GET', 'search/geofences', params);
   }
 
 
@@ -103,7 +103,7 @@ class Search {
       country,
     };
 
-    return Http.request('GET', 'v1/search/autocomplete', params);
+    return Http.request('GET', 'search/autocomplete', params);
   }
 }
 

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -44,10 +44,7 @@ class Track {
       userId,
     };
 
-    const basePath = Storage.getItem(Storage.BASE_API_PATH) || 'v1';
-    const trackEndpoint = `${basePath}/track`;
-
-    const response = await Http.request('POST', trackEndpoint, body);
+    const response = await Http.request('POST', 'track', body);
     response.location = { latitude, longitude, accuracy };
 
     return response;

--- a/src/api/trips.js
+++ b/src/api/trips.js
@@ -23,8 +23,7 @@ class Trips {
       approachingThreshold,
     };
 
-    const basePath = Storage.getItem(Storage.BASE_API_PATH) || 'v1';
-    return Http.request('POST', `${basePath}/trips`, params);
+    return Http.request('POST', `trips`, params);
   }
 
   static async updateTrip(tripOptions={}, status) {
@@ -49,8 +48,7 @@ class Trips {
       approachingThreshold,
     };
 
-    const basePath = Storage.getItem(Storage.BASE_API_PATH) || 'v1';
-    return Http.request('PATCH', `${basePath}/trips/${externalId}/update`, params);
+    return Http.request('PATCH', `trips/${externalId}/update`, params);
   }
 }
 

--- a/src/http.js
+++ b/src/http.js
@@ -10,8 +10,9 @@ class Http {
     return new Promise((resolve, reject) => {
 
       const xhr = new XMLHttpRequest();
+      const basePath = Storage.getItem(Storage.BASE_API_PATH) || 'v1';
 
-      let url = `${API_HOST.getHost()}/${path}`;
+      let url = `${API_HOST.getHost()}/${basePath}/${path}`;
 
       // remove undefined values
       let body = {};

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.4.0-beta';
+export default '3.5.0-beta';

--- a/test/api/search.test.js
+++ b/test/api/search.test.js
@@ -127,7 +127,7 @@ describe('Search', () => {
 
         return Search.autocomplete({ query })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined });
             expect(response).to.equal(autocompleteResponse);
           });
       });
@@ -141,7 +141,7 @@ describe('Search', () => {
 
         return Search.autocomplete({ near, query, limit, layers, country })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'v1/search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country });
             expect(response).to.equal(autocompleteResponse);
           });
       });

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -36,7 +36,7 @@ describe('Trips', () => {
         return Trips.startTrip()
           .then(() => {
             expect(httpStub).to.have.callCount(1);
-            expect(httpStub).to.have.been.calledWith('POST', 'v1/trips', {
+            expect(httpStub).to.have.been.calledWith('POST', 'trips', {
               userId,
               destinationGeofenceTag: undefined,
               destinationGeofenceExternalId: undefined,
@@ -62,7 +62,7 @@ describe('Trips', () => {
         return Trips.startTrip(tripOptions)
           .then(() => {
             expect(httpStub).to.have.callCount(1);
-            expect(httpStub).to.have.been.calledWith('POST', 'v1/trips', {
+            expect(httpStub).to.have.been.calledWith('POST', 'trips', {
               userId,
               destinationGeofenceTag: 'store',
               destinationGeofenceExternalId: '123',
@@ -92,7 +92,7 @@ describe('Trips', () => {
         return Trips.updateTrip(tripOptions)
           .then(() => {
             expect(httpStub).to.have.callCount(1);
-            expect(httpStub).to.have.been.calledWith('PATCH', `v1/trips/${externalId}/update`, {
+            expect(httpStub).to.have.been.calledWith('PATCH', `trips/${externalId}/update`, {
               userId,
               destinationGeofenceTag: 'store',
               destinationGeofenceExternalId: '123',
@@ -124,7 +124,7 @@ describe('Trips', () => {
         return Trips.updateTrip(tripOptions, status)
           .then(() => {
             expect(httpStub).to.have.callCount(1);
-            expect(httpStub).to.have.been.calledWith('PATCH', `v1/trips/${externalId}/update`, {
+            expect(httpStub).to.have.been.calledWith('PATCH', `trips/${externalId}/update`, {
               userId,
               destinationGeofenceTag: 'store',
               destinationGeofenceExternalId: '123',

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -37,7 +37,7 @@ describe('Http', () => {
 
     beforeEach(() => {
       getItemStub.withArgs(Storage.PUBLISHABLE_KEY).returns(publishableKey);
-      httpRequest = Http.request('PUT', 'v1/users/userId', { valid: true, invalid: undefined });
+      httpRequest = Http.request('PUT', 'users/userId', { valid: true, invalid: undefined });
     });
 
     describe('success', () => {
@@ -212,7 +212,7 @@ describe('Http', () => {
         getItemStub.withArgs(Storage.PUBLISHABLE_KEY).returns(null);
 
         try {
-          await Http.request('PUT', 'v1/users/userId', {});
+          await Http.request('PUT', 'users/userId', {});
         } catch (e) {
           expect(e).to.equal(STATUS.ERROR_PUBLISHABLE_KEY);
         }
@@ -239,7 +239,7 @@ describe('Http', () => {
     it('should inject GET parameters into the url querystring', async () => {
       getItemStub.withArgs(Storage.PUBLISHABLE_KEY).returns(publishableKey);
 
-      const httpRequest = Http.request('GET', 'v1/geocode/forward', data);
+      const httpRequest = Http.request('GET', 'geocode/forward', data);
 
       setTimeout(() => {
         request.respond(200, {}, successResponse);
@@ -256,7 +256,7 @@ describe('Http', () => {
     it('should not append querystring of no params', async () => {
       getItemStub.withArgs(Storage.PUBLISHABLE_KEY).returns(publishableKey);
 
-      const httpRequest = Http.request('GET', 'v1/geocode/forward', {});
+      const httpRequest = Http.request('GET', 'geocode/forward', {});
 
       setTimeout(() => {
         request.respond(200, {}, successResponse);
@@ -281,7 +281,7 @@ describe('Http', () => {
       getItemStub.withArgs(Storage.CUSTOM_HEADERS).returns(JSON.stringify(customHeaders));
 
       const data = { query: '20 Jay Street' };
-      const httpRequest = Http.request('GET', 'v1/geocode/forward', data);
+      const httpRequest = Http.request('GET', 'geocode/forward', data);
 
       setTimeout(() => {
         request.respond(200, {}, successResponse);


### PR DESCRIPTION
Story details: https://app.shortcut.com/radarlabs/story/12086

All tests pass
```
  Context
    getContext
      location permissions denied
        ✓ should throw a navigation error
      location permissions approved
        ✓ should return a context response

  Geocoding
    geocode
      ✓ should return an address
    reverseGeocode
      location permissions denied
        ✓ should propagate the navigator error
      location permissions approved
        ✓ should return a geocode response
    ipGeocode
      ✓ should return a geocode response

  Routing
    getDistanceToDestination
      location permissions denied
        ✓ should throw a navigation error
      location permissions approved
        no args given
          ✓ should return a routing response
        all args given
          ✓ should return a routing response
    getMatrixDistances
      location permissions denied
        ✓ should throw a navigation error
      location permissions approved
        no args given
          ✓ should return a routing response
        all args given
          ✓ should return a routing response

  Search
    searchPlaces
      location permissions denied
        ✓ should propagate the navigator error
      location permissions approved
        ✓ should return a placeSearch response
      location is given
        ✓ should return a placeSearch response
    searchGeofences
      location permissions denied
        ✓ should propagate the navigator error
      location permissions approved
        ✓ should return a geofenceSearch response
      location is given
        ✓ should return a geofenceSearch response
    autocomplete
      params are not provided
        ✓ should have undefined params and return an autocomplete response
      params are provided
        ✓ should return an autocomplete response

  Track
    trackOnce
      location permissions denied
        ✓ should propagate the navigator error
      location permissions approved
        ✓ should return a track response with metadata
        ✓ should return a track response without metadata

  Trips
    startTrip
      called without tripOptions
        ✓ should include tripOptions each set to unknown
        ✓ should include tripOptions
    updateTrip
      called without status
        ✓ should include status unknown
      called with status
        ✓ should include status

  Device
    getId
      deviceId has not been set
        ✓ should generate a new deviceId in storage, and return the value
      deviceId has already been set
        ✓ should return the deviceId stored saved in the storage

  Http
    http requests
      success
        ✓ should return api response on success
        ✓ should always include Device-Type and SDK-Version headers
        ✓ should filter out undefined values in data
      error
        ✓ should return bad request error
        ✓ should return bad request error
        ✓ should return unauthorized error
        ✓ should return payment required error
        ✓ should return forbidden error
        ✓ should return not found error
        ✓ should return rate limit error
        ✓ should return server error
        ✓ should return unknown error
        ✓ should respond with server error status on request error
        ✓ should respond with network error status on timeout
        ✓ should return a publishable key error if not set
        ✓ should return a server error on invalid JSON
    GET request
      ✓ should inject GET parameters into the url querystring
      ✓ should not append querystring of no params
    custom headers
      ✓ should include headers in request

  Radar
    VERSION
      ✓ should return sdk version
    STATUS
      ✓ should return the list of possible status codes
    initialize
      no publishable key given
        ✓ should print a warning to the console
      called with publishable key
        ✓ should save publishable key to storage
    setHost
      ✓ should save the host to storage
    setUserId
      no userId given
        ✓ should delete userId from storage
      userId given
        ✓ should save userId in storage
    setDeviceId
      no deviceId given
        ✓ should delete deviceId from storage
      deviceId given
        ✓ should save deviceId in storage
        ✓ should save deviceId with installId in storage
    setDescription
      no description given
        ✓ should delete description from storage
      description given
        ✓ should save description in storage
    setMetadata
      no metadata given
        ✓ should delete metadata from storage
      metadata given
        ✓ should save metadata in storage
    setRequestHeaders
      no headers given
        ✓ should delete metadata from storage
      headers given
        ✓ should save metadata in storage
    api errors
      Radar error
        ✓ should return the error enum and empty object
      Http Error
        ✓ should return the error enum and response object
      Unknown
        ✓ should return the unknown error and empty object
    getLocation
      ✓ should propagate the err if not successful
      ✓ should succeed
    trackOnce
      ✓ should call trackOnce if the first arg is a callback
      ✓ should call trackOnce if the first arg is a location object
      ✓ should not throw an error if no callback given
    getContext
      ✓ should call getContext if the first arg is a callback
      ✓ should call getContext if the first arg is a location
    searchPlaces
      ✓ should call searchPlaces
    searchGeofences
      ✓ should call searchGeofences
    autocomplete
      ✓ should call autocomplete
    geocode
      ✓ should call geocode
    reverseGeocode
      ✓ should call reverseGeocode if the first arg is a callback
      ✓ should call reverseGeocodeLocation if the first arg is a location object
    ipGeocode
      ✓ should call ipGeocode if the first arg is a callback
      ✓ should call ipGeocode is the first arg is an object
    getDistance
      ✓ should call getDistanceToDestination

  Navigator
    ✓ should report a location error if geolocation is not available
    ✓ should report a location error if position coordinates are not available
    ✓ should report a permissions error if the user denies location permissions
    ✓ should report a location error if the device errors out fetching location
    ✓ should succeed

  Storage
    getItem
      ✓ should return value of sessionStorage from a given key
      ✓ should return null if key not found
      ✓ should return null if sessionStorage key is undefined
    setItem
      ✓ should write the key and value to the browsers sessionStorage
    clear & removeItem
      ✓ should delete session Storage
      ✓ should clear session storage

  VERSION
    ✓ should match version in package.json
    ✓ should match version in package-lock.json


  96 passing (87ms)
```