### PR TITLE
Hotfix null and undefined check for session storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.5.0-beta",
+  "version": "3.5.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.5.0-beta",
+      "version": "3.5.0-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.5.0-beta",
+  "version": "3.5.0-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api_host.js
+++ b/src/api_host.js
@@ -1,6 +1,7 @@
 import Storage from './storage';
 
-const DEFAULT_HOST = 'https://api.radar.io';
+export const DEFAULT_HOST = 'https://api.radar.io';
+export const API_VERSION = 'v1';
 
 class API_HOST {
   static getHost() {

--- a/src/http.js
+++ b/src/http.js
@@ -1,7 +1,7 @@
 import Storage from './storage';
 
 // consts
-import API_HOST from './api_host';
+import API_HOST, { API_VERSION } from './api_host';
 import SDK_VERSION from './version';
 import STATUS from './status';
 
@@ -10,7 +10,7 @@ class Http {
     return new Promise((resolve, reject) => {
 
       const xhr = new XMLHttpRequest();
-      const basePath = Storage.getItem(Storage.BASE_API_PATH) || 'v1';
+      const basePath = Storage.getItem(Storage.BASE_API_PATH) || API_VERSION;
 
       let url = `${API_HOST.getHost()}/${basePath}/${path}`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import Storage from './storage';
 import SDK_VERSION from './version';
 import STATUS from './status';
 import { TRIP_STATUS } from './tripStatus';
+import { API_VERSION } from './api_host';
 
 const defaultCallback = () => {};
 
@@ -51,7 +52,7 @@ class Radar {
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
   }
 
-  static setHost(host, baseApiPath) {
+  static setHost(host, baseApiPath = API_VERSION) {
     Storage.setItem(Storage.HOST, host);
     Storage.setItem(Storage.BASE_API_PATH, baseApiPath);
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -44,6 +44,9 @@ class Storage {
         if (!storage) {
             return;
         }
+        if (value === undefined || value === null) {
+            return;
+        }
         sessionStorage.setItem(key, value);
     }
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.5.0-beta';
+export default '3.5.0-beta.1';


### PR DESCRIPTION
## Issue
When setting items in session storage, `null` and `undefined` values were being set as strings `"null"`, `"undefined"`. 

According to the existing logic in `Storage.getItem`, these values weren't intended to be stored in the first place. This check in `Storage.getItem` is never hit since every value pulled from storage are strings.

https://github.com/radarlabs/radar-sdk-js/blob/2cc470776b8989bf5ae02e711056ecce7ec1f229/src/storage.js#L53-L64

This caused an error in every API request made in #75. Calling `Radar.setHost(apiHost)` would set the url to be `apiHost/undefined/...` when it should've defaulted to `apiHost/v1/...`