### PR TITLE
Update trips behavior to new endpoints and new /track tripOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.5.1",
+  "version": "3.6.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.5.1",
+      "version": "3.6.0-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.5.0-beta.2",
+  "version": "3.5.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.5.0-beta.2",
+      "version": "3.5.0-beta.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.5.1",
+  "version": "3.6.0-beta",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.io",
   "license": "Apache-2.0",
-  "version": "3.5.0-beta.2",
+  "version": "3.5.0-beta.3",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -31,7 +31,7 @@ class Track {
     let tripOptions = Storage.getItem(Storage.TRIP_OPTIONS);
     if (tripOptions) {
       tripOptions = JSON.parse(tripOptions);
-      tripOptions.v2 = true;
+      tripOptions.version = '2';
     }
 
     const body = {

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -31,6 +31,7 @@ class Track {
     let tripOptions = Storage.getItem(Storage.TRIP_OPTIONS);
     if (tripOptions) {
       tripOptions = JSON.parse(tripOptions);
+      tripOptions.v2 = true;
     }
 
     const body = {

--- a/src/api/trips.js
+++ b/src/api/trips.js
@@ -1,8 +1,33 @@
 import Http from '../http';
+import Storage from '../storage';
 
 class Trips {
+  static async startTrip(tripOptions={}) {
+    const userId = Storage.getItem(Storage.USER_ID);
+    const {
+      externalId,
+      destinationGeofenceTag,
+      destinationGeofenceExternalId,
+      mode,
+      metadata,
+      approachingThreshold,
+    } = tripOptions;
+
+    const params = {
+      userId,
+      externalId,
+      destinationGeofenceTag,
+      destinationGeofenceExternalId,
+      mode,
+      metadata,
+      approachingThreshold,
+    };
+
+    return Http.request('POST', `trips`, params);
+  }
 
   static async updateTrip(tripOptions={}, status) {
+    const userId = Storage.getItem(Storage.USER_ID);
 
     const {
       externalId,
@@ -14,6 +39,7 @@ class Trips {
     } = tripOptions;
 
     const params = {
+      userId,
       externalId,
       status,
       destinationGeofenceTag,
@@ -23,7 +49,7 @@ class Trips {
       approachingThreshold,
     };
 
-    return Http.request('PATCH', `trips/${externalId}`, params);
+    return Http.request('PATCH', `trips/${externalId}/update`, params);
   }
 }
 

--- a/src/api/trips.js
+++ b/src/api/trips.js
@@ -1,6 +1,9 @@
 import Http from '../http';
 import Storage from '../storage';
 
+// https://stackoverflow.com/a/44198641
+const isValidDate = (date) => date && Object.prototype.toString.call(date) === '[object Date]' && !isNaN(date);
+
 class Trips {
   static async startTrip(tripOptions={}) {
     const userId = Storage.getItem(Storage.USER_ID);
@@ -11,6 +14,7 @@ class Trips {
       mode,
       metadata,
       approachingThreshold,
+      scheduledArrivalAt,
     } = tripOptions;
 
     const params = {
@@ -22,6 +26,12 @@ class Trips {
       metadata,
       approachingThreshold,
     };
+
+    if (isValidDate(scheduledArrivalAt)) {
+      params.scheduledArrivalAt = scheduledArrivalAt.toJSON();
+    } else {
+      params.scheduledArrivalAt = undefined;
+    }
 
     return Http.request('POST', `trips`, params);
   }
@@ -36,6 +46,7 @@ class Trips {
       mode,
       metadata,
       approachingThreshold,
+      scheduledArrivalAt,
     } = tripOptions;
 
     const params = {
@@ -47,7 +58,14 @@ class Trips {
       mode,
       metadata,
       approachingThreshold,
+      scheduledArrivalAt,
     };
+
+    if (isValidDate(scheduledArrivalAt)) {
+      params.scheduledArrivalAt = scheduledArrivalAt.toJSON();
+    } else {
+      params.scheduledArrivalAt = undefined;
+    }
 
     return Http.request('PATCH', `trips/${externalId}/update`, params);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -166,8 +166,7 @@ class Radar {
     Trips.startTrip(tripOptions)
       .then((response) => {
         Radar.setTripOptions(tripOptions);
-        // default events to `[]` for backwards compatibility
-        callback(null, { trip: response.trip, events: response.events || [], status: STATUS.SUCCESS }, response);
+        callback(null, { trip: response.trip, events: response.events, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -163,10 +163,11 @@ class Radar {
   }
 
   static startTrip(tripOptions, callback=defaultCallback) {
-    Trips.updateTrip(tripOptions, TRIP_STATUS.STARTED)
+    Trips.startTrip(tripOptions)
       .then((response) => {
         Radar.setTripOptions(tripOptions);
-        callback(null, { trip: response.trip, events: response.events, status: STATUS.SUCCESS }, response);
+        // default events to `[]` for backwards compatibility
+        callback(null, { trip: response.trip, events: response.events || [], status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.5.0-beta.2';
+export default '3.5.0-beta.3';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.5.1';
+export default '3.6.0-beta';

--- a/test/api/track.test.js
+++ b/test/api/track.test.js
@@ -104,7 +104,7 @@ describe('Track', () => {
             const trackArgs = httpStub.getCall(0).args;
             expect(trackArgs[0]).to.equal('POST');
             expect(trackArgs[1]).to.equal('track');
-            expect(trackArgs[2].tripOptions).to.deep.equal({ ...tripOptions, v2: true });
+            expect(trackArgs[2].tripOptions).to.deep.equal({ ...tripOptions, version: '2' });
           });
         });
     });

--- a/test/api/track.test.js
+++ b/test/api/track.test.js
@@ -104,7 +104,7 @@ describe('Track', () => {
             const trackArgs = httpStub.getCall(0).args;
             expect(trackArgs[0]).to.equal('POST');
             expect(trackArgs[1]).to.equal('track');
-            expect(trackArgs[2].tripOptions).to.deep.equal(tripOptions);
+            expect(trackArgs[2].tripOptions).to.deep.equal({ ...tripOptions, v2: true });
           });
         });
     });

--- a/test/api/trips.test.js
+++ b/test/api/trips.test.js
@@ -44,6 +44,7 @@ describe('Trips', () => {
               metadata: undefined,
               mode: undefined,
               approachingThreshold: undefined,
+              scheduledArrivalAt: undefined,
            });
           });
       });
@@ -52,6 +53,7 @@ describe('Trips', () => {
     describe('called with tripOptions', () => {
       it('should include tripOptions', () => {
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -59,6 +61,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         return Trips.startTrip(tripOptions)
@@ -67,6 +70,7 @@ describe('Trips', () => {
             expect(httpStub).to.have.been.calledWith('POST', 'trips', {
               userId,
               ...tripOptions,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
            });
           });
       });
@@ -75,6 +79,7 @@ describe('Trips', () => {
     describe('called with userId set', () => {
       it('should include userId', () => {
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -82,6 +87,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         return Trips.startTrip(tripOptions)
@@ -90,6 +96,7 @@ describe('Trips', () => {
             expect(httpStub).to.have.been.calledWith('POST', 'trips', {
               userId,
               ...tripOptions,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
            });
           });
       });
@@ -100,6 +107,7 @@ describe('Trips', () => {
         getItemStub.withArgs(Storage.USER_ID).returns(undefined);
 
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -107,6 +115,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         return Trips.startTrip(tripOptions)
@@ -115,6 +124,33 @@ describe('Trips', () => {
             expect(httpStub).to.have.been.calledWith('POST', 'trips', {
               userId: undefined,
               ...tripOptions,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
+           });
+          });
+      });
+    });
+
+    describe('called with an invalid date for scheduledArrivalAt', () => {
+      it('should have scheduledArrivalAt set to undefined', () => {
+        const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = '123456';
+        const tripOptions = {
+          userId,
+          externalId,
+          destinationGeofenceTag: 'store',
+          destinationGeofenceExternalId: '123',
+          mode: 'car',
+          metadata: { car: 'red jeep' },
+          approachingThreshold: 3,
+          scheduledArrivalAt,
+        };
+
+        return Trips.startTrip(tripOptions)
+          .then(() => {
+            expect(httpStub).to.have.callCount(1);
+            expect(httpStub).to.have.been.calledWith('POST', 'trips', {
+              ...tripOptions,
+              scheduledArrivalAt: undefined,
            });
           });
       });
@@ -125,12 +161,14 @@ describe('Trips', () => {
     describe('called without status', () => {
       it('should include status unknown', () => {
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
           destinationGeofenceExternalId: '123',
           mode: 'car',
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         return Trips.updateTrip(tripOptions)
@@ -145,6 +183,7 @@ describe('Trips', () => {
               mode: 'car',
               status: TRIP_STATUS.UNKNOWN,
               approachingThreshold: 3,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
            });
           });
       });
@@ -153,6 +192,7 @@ describe('Trips', () => {
     describe('called with status', () => {
       it('should include status', () => {
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -160,6 +200,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         const status = TRIP_STATUS.STARTED;
@@ -176,6 +217,7 @@ describe('Trips', () => {
               mode: 'car',
               status: TRIP_STATUS.STARTED,
               approachingThreshold: 3,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
            });
           });
       });
@@ -184,6 +226,7 @@ describe('Trips', () => {
     describe('called with userId set', () => {
       it('should include userId', () => {
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -191,6 +234,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         const status = TRIP_STATUS.STARTED;
@@ -202,6 +246,7 @@ describe('Trips', () => {
               ...tripOptions,
               userId,
               status: TRIP_STATUS.STARTED,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
            });
           });
       });
@@ -212,6 +257,7 @@ describe('Trips', () => {
         getItemStub.withArgs(Storage.USER_ID).returns(undefined);
 
         const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = new Date();
         const tripOptions = {
           externalId,
           destinationGeofenceTag: 'store',
@@ -219,6 +265,7 @@ describe('Trips', () => {
           mode: 'car',
           metadata: { car: 'red jeep' },
           approachingThreshold: 3,
+          scheduledArrivalAt,
         };
 
         const status = TRIP_STATUS.STARTED;
@@ -230,6 +277,36 @@ describe('Trips', () => {
               ...tripOptions,
               userId: undefined,
               status: TRIP_STATUS.STARTED,
+              scheduledArrivalAt: scheduledArrivalAt.toJSON(),
+           });
+          });
+      });
+    });
+
+    describe('called with an invalid date for scheduledArrivalAt', () => {
+      it('should have scheduledArrivalAt set to undefined', () => {
+        const externalId = 'trip-abc-123';
+        const scheduledArrivalAt = '123456';
+        const tripOptions = {
+          userId,
+          externalId,
+          destinationGeofenceTag: 'store',
+          destinationGeofenceExternalId: '123',
+          mode: 'car',
+          metadata: { car: 'red jeep' },
+          approachingThreshold: 3,
+          scheduledArrivalAt,
+        };
+
+        const status = TRIP_STATUS.STARTED;
+
+        return Trips.updateTrip(tripOptions, status)
+          .then(() => {
+            expect(httpStub).to.have.callCount(1);
+            expect(httpStub).to.have.been.calledWith('PATCH', `trips/${externalId}/update`, {
+              ...tripOptions,
+              status: TRIP_STATUS.STARTED,
+              scheduledArrivalAt: undefined,
            });
           });
       });


### PR DESCRIPTION
## Summary
- Add `startTrip` service to use new `POST` endpoint
- Update `updateTrip` to new `PATCH` endpoint
- Add `version` field to `tripOptions` on `track`
- Add `scheduledArrivalAt` to `tripOptions`
- Update tests

Fixes TRIPS-92, TRIPS-172

## QA

### `startTrip`
<img width="1061" alt="Screenshot 2023-02-07 at 9 46 33 AM" src="https://user-images.githubusercontent.com/32653448/217312224-feaf12dc-ceb6-490a-a6cd-4e00da2b3c7d.png">

<img width="1569" alt="Screenshot 2023-02-07 at 9 45 45 AM" src="https://user-images.githubusercontent.com/32653448/217312266-af0266f5-ee17-4be0-b417-bc7477f52161.png">

### `/track`
<img width="1190" alt="Screenshot 2023-02-07 at 9 54 43 AM" src="https://user-images.githubusercontent.com/32653448/217312294-3589db25-5340-496b-86c5-b31807444dd5.png">

<img width="1573" alt="Screenshot 2023-02-07 at 9 56 18 AM" src="https://user-images.githubusercontent.com/32653448/217312332-662c68eb-e25c-4e9b-8ac4-a8de6faef859.png">

### `updateTrip`
<img width="1174" alt="Screenshot 2023-02-07 at 9 57 50 AM" src="https://user-images.githubusercontent.com/32653448/217312353-1b181a20-3cce-49f4-9724-1f2ef7c4fe2a.png">