### PR TITLE
RAD-5740: cache-recent-locations-in-websdk-with-variable-ttl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.5.0",
+  "version": "3.5.1-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.5.0-beta.2",
+      "version": "3.5.1-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.5.1-beta",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.5.1-beta",
+      "version": "3.5.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.5.0",
+  "version": "3.5.1-beta",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.5.1-beta",
+  "version": "3.5.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -11,7 +11,7 @@ class Track {
     let { latitude, longitude, accuracy } = params;
 
     let useCacheLocation = false
-    let locationlocationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
+    let locationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
     let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
 
     if(locationTimeToLive && cachedTimeString){

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -10,7 +10,16 @@ class Track {
   static async trackOnce(params={}) {
     let { latitude, longitude, accuracy } = params;
 
-    if (!latitude || !longitude) {
+    // What do I do about accuracy
+    let useCacheLocation = false
+    let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
+
+    if(timeToLive && cachedTimeString){
+      let cachedTime = new Date(cachedTimeString).getTime()
+      useCacheLocation = Date.now() < cachedTime + timeToLive * 60
+    }
+
+    if ((!latitude || !longitude) && !useCacheLocation) {
       const deviceLocation = await Navigator.getCurrentPosition();
       latitude = deviceLocation.latitude;
       longitude = deviceLocation.longitude;

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -11,6 +11,7 @@ class Track {
     let { latitude, longitude, accuracy } = params;
 
     let useCacheLocation = false
+    let timeToLive = Storage.getItem(Storage.LOCATION_TIME_TO_LIVE)
     let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
 
     if(timeToLive && cachedTimeString){

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -10,29 +10,11 @@ class Track {
   static async trackOnce(params={}) {
     let { latitude, longitude, accuracy } = params;
 
-    let useCacheLocation = false
-    let locationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
-    let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
-
-    if(locationTimeToLive && cachedTimeString){
-      let cachedTime = parseInt(cachedTimeString)
-      useCacheLocation = Date.now() < cachedTime + locationTimeToLive * 60 * 1000 && (!latitude || !longitude)
-    }
-
-    if(useCacheLocation){
-      latitude = Storage.getItem(Storage.LATITUDE)
-      longitude = Storage.getItem(Storage.LONGITUDE)
-      accuracy = Storage.getItem(Storage.ACCURACY)
-    } else if ((!latitude || !longitude)) {
+    if (!latitude || !longitude) {
       const deviceLocation = await Navigator.getCurrentPosition();
       latitude = deviceLocation.latitude;
       longitude = deviceLocation.longitude;
       accuracy = deviceLocation.accuracy;
-
-      Storage.setItem(Storage.LAST_LOCATION_TIME, Date.now())
-      Storage.setItem(Storage.LATITUDE, latitude)
-      Storage.setItem(Storage.LONGITUDE, longitude)
-      Storage.setItem(Storage.ACCURACY, accuracy)
     }
 
     const deviceId = Device.getId();

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -10,20 +10,28 @@ class Track {
   static async trackOnce(params={}) {
     let { latitude, longitude, accuracy } = params;
 
-    // What do I do about accuracy
     let useCacheLocation = false
     let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
 
     if(timeToLive && cachedTimeString){
       let cachedTime = new Date(cachedTimeString).getTime()
-      useCacheLocation = Date.now() < cachedTime + timeToLive * 60
+      useCacheLocation = Date.now() < cachedTime + timeToLive * 60 && (!latitude || !longitude) 
     }
 
-    if ((!latitude || !longitude) && !useCacheLocation) {
+    if(useCacheLocation){
+      latitude = Storage.getItem(Storage.LATITUDE)
+      longitude = Storage.getItem(Storage.LONGITUDE)
+      accuracy = Storage.getItem(Storage.ACCURACY)
+    } else if ((!latitude || !longitude)) {
       const deviceLocation = await Navigator.getCurrentPosition();
       latitude = deviceLocation.latitude;
       longitude = deviceLocation.longitude;
       accuracy = deviceLocation.accuracy;
+
+      Storage.setItem(Storage.LAST_LOCATION_TIME, Date.now())
+      Storage.setItem(Storage.LATITUDE, latitude)
+      Storage.setItem(Storage.LONGITUDE, longitude)
+      Storage.setItem(Storage.ACCURACY, accuracy)
     }
 
     const deviceId = Device.getId();

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -11,12 +11,12 @@ class Track {
     let { latitude, longitude, accuracy } = params;
 
     let useCacheLocation = false
-    let timeToLive = Storage.getItem(Storage.LOCATION_TIME_TO_LIVE)
+    let timeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
     let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
 
     if(timeToLive && cachedTimeString){
-      let cachedTime = new Date(cachedTimeString).getTime()
-      useCacheLocation = Date.now() < cachedTime + timeToLive * 60 && (!latitude || !longitude) 
+      let cachedTime = parseInt(cachedTimeString)
+      useCacheLocation = Date.now() < cachedTime + timeToLive * 60 * 1000 && (!latitude || !longitude)
     }
 
     if(useCacheLocation){

--- a/src/api/track.js
+++ b/src/api/track.js
@@ -11,12 +11,12 @@ class Track {
     let { latitude, longitude, accuracy } = params;
 
     let useCacheLocation = false
-    let timeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
+    let locationlocationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
     let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
 
-    if(timeToLive && cachedTimeString){
+    if(locationTimeToLive && cachedTimeString){
       let cachedTime = parseInt(cachedTimeString)
-      useCacheLocation = Date.now() < cachedTime + timeToLive * 60 * 1000 && (!latitude || !longitude)
+      useCacheLocation = Date.now() < cachedTime + locationTimeToLive * 60 * 1000 && (!latitude || !longitude)
     }
 
     if(useCacheLocation){

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const defaultCallback = () => {};
 
 const handleError = (callback) => {
   return (err) => {
-
+    
     // Radar Error
     if (typeof err === 'string') {
       callback(err, {});
@@ -46,11 +46,19 @@ class Radar {
     return STATUS;
   }
 
-  static initialize(publishableKey) {
+  static initialize(publishableKey, options={}) {
     if (!publishableKey) {
       console.error('Radar "initialize" was called without a publishable key');
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
+
+    if(options){
+      let {timeToLive} = options
+
+      if(timeToLive && typeof(timeToLive) === 'number'){
+        Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, timeToLive)
+      }
+    }
   }
 
   static setHost(host, baseApiPath = API_VERSION) {

--- a/src/index.js
+++ b/src/index.js
@@ -52,16 +52,15 @@ class Radar {
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
 
-    if(Object.keys(options).length === 0){
-      const {locationTimeToLive} = options
 
-      if (locationTimeToLive) {
-        const number = Number(locationTimeToLive);
-        if (Number.isNaN(number)) {
-          console.warn('Radar SDK: invalid number for option "locationTimeToLive"');
-        } else {
-          Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, locationTimeToLive);
-        }
+    const {cacheLocationMinutes} = options
+
+    if (cacheLocationMinutes) {
+      const number = Number(cacheLocationMinutes);
+      if (Number.isNaN(number)) {
+        console.warn('Radar SDK: invalid number for option "cacheLocationMinutes"');
+      } else {
+        Storage.setItem(Storage.CACHE_LOCATION_MINUTES, cacheLocationMinutes);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,6 @@ class Radar {
       console.error('Radar "initialize" was called without a publishable key');
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
-
     if(options){
       let {timeToLive} = options
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,7 @@ class Radar {
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
 
-
-    const {cacheLocationMinutes} = options
+    const { cacheLocationMinutes } = options;
 
     if (cacheLocationMinutes) {
       const number = Number(cacheLocationMinutes);
@@ -62,6 +61,8 @@ class Radar {
       } else {
         Storage.setItem(Storage.CACHE_LOCATION_MINUTES, cacheLocationMinutes);
       }
+    }else{
+      Storage.removeItem(Storage.CACHE_LOCATION_MINUTES);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,12 +61,12 @@ class Radar {
       } else {
         Storage.setItem(Storage.CACHE_LOCATION_MINUTES, cacheLocationMinutes);
       }
-    }else{
+    } else {
       Storage.removeItem(Storage.CACHE_LOCATION_MINUTES);
     }
   }
 
-  static setHost(host, baseApiPath = API_VERSION) {
+  static setHost(host, baseApiPath=API_VERSION) {
     Storage.setItem(Storage.HOST, host);
     Storage.setItem(Storage.BASE_API_PATH, baseApiPath);
   }
@@ -163,7 +163,6 @@ class Radar {
 
     if (typeof arg0 === 'function') {
       callback = arg0;
-
     } else {
       location = arg0;
       callback = arg1;
@@ -293,7 +292,6 @@ class Radar {
 
     if (typeof arg0 === 'function') {
       callback = arg0;
-
     } else if (typeof arg0 === 'object') {
       geocodeOptions = arg0;
       callback = arg1;

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const defaultCallback = () => {};
 
 const handleError = (callback) => {
   return (err) => {
-    
+
     // Radar Error
     if (typeof err === 'string') {
       callback(err, {});

--- a/src/index.js
+++ b/src/index.js
@@ -51,11 +51,17 @@ class Radar {
       console.error('Radar "initialize" was called without a publishable key');
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
-    if(options){
-      let {locationTimeToLive} = options
 
-      if(locationTimeToLive && typeof(locationTimeToLive) === 'number'){
-        Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, locationTimeToLive)
+    if(Object.keys(options).length === 0){
+      const {locationTimeToLive} = options
+
+      if (locationTimeToLive) {
+        const number = Number(locationTimeToLive);
+        if (Number.isNaN(number)) {
+          console.warn('Radar SDK: invalid number for option "locationTimeToLive"');
+        } else {
+          Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, locationTimeToLive);
+        }
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,10 @@ class Radar {
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
     if(options){
-      let {timeToLive} = options
+      let {locationTimeToLive} = options
 
-      if(timeToLive && typeof(timeToLive) === 'number'){
-        Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, timeToLive)
+      if(locationTimeToLive && typeof(locationTimeToLive) === 'number'){
+        Storage.setItem(Storage.LOCATION_TIME_TO_LIVE, locationTimeToLive)
       }
     }
   }

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -11,7 +11,6 @@ class Navigator {
 
       let locationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
       let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
-      debugger;
       if(locationTimeToLive && cachedTimeString){
         let cachedTime = parseInt(cachedTimeString)
         if(Date.now() < cachedTime + locationTimeToLive * 60 * 1000){

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -13,10 +13,12 @@ class Navigator {
       if (cacheLocationMinutes) {
         try {
           const lastLocation = JSON.parse(Storage.getItem(Storage.LAST_LOCATION));
-          const { latitude, longitude, accuracy } = lastLocation;
-          if (Date.now() < parseInt(lastLocation.expiresAt)) {            // check expiration stuff goes here
-            if(latitude && longitude && accuracy){
-              return resolve({ latitude, longitude, accuracy });
+          if(lastLocation){
+            const { latitude, longitude, accuracy } = lastLocation;
+            if (Date.now() < parseInt(lastLocation.expiresAt)) {            // check expiration stuff goes here
+              if(latitude && longitude && accuracy){
+                return resolve({ latitude, longitude, accuracy });
+              }
             }
           }
         } catch (e) {

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -13,10 +13,10 @@ class Navigator {
       if (cacheLocationMinutes) {
         try {
           const lastLocation = JSON.parse(Storage.getItem(Storage.LAST_LOCATION));
-          if(lastLocation){
+          if (lastLocation) {
             const { latitude, longitude, accuracy } = lastLocation;
             if (Date.now() < parseInt(lastLocation.expiresAt)) {            // check expiration stuff goes here
-              if(latitude && longitude && accuracy){
+              if (latitude && longitude && accuracy) {
                 return resolve({ latitude, longitude, accuracy });
               }
             }

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -1,4 +1,5 @@
 import STATUS from './status';
+import Storage from './storage';
 
 class Navigator {
   static getCurrentPosition() {
@@ -6,6 +7,21 @@ class Navigator {
 
       if (!navigator || !navigator.geolocation) {
         return reject(STATUS.ERROR_LOCATION);
+      }
+
+      let locationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE))
+      let cachedTimeString = Storage.getItem(Storage.LAST_LOCATION_TIME)
+      debugger;
+      if(locationTimeToLive && cachedTimeString){
+        let cachedTime = parseInt(cachedTimeString)
+        if(Date.now() < cachedTime + locationTimeToLive * 60 * 1000){
+          let latitude = Storage.getItem(Storage.LATITUDE)
+          let longitude = Storage.getItem(Storage.LONGITUDE)
+          let accuracy = Storage.getItem(Storage.ACCURACY)
+          if(latitude && longitude && accuracy){
+            return resolve({ latitude, longitude, accuracy });
+          }
+        }
       }
 
       navigator.geolocation.getCurrentPosition(
@@ -16,6 +32,11 @@ class Navigator {
           }
 
           const { latitude, longitude, accuracy } = position.coords;
+
+          Storage.setItem(Storage.LAST_LOCATION_TIME, Date.now())
+          Storage.setItem(Storage.LATITUDE, latitude)
+          Storage.setItem(Storage.LONGITUDE, longitude)
+          Storage.setItem(Storage.ACCURACY, accuracy)
 
           return resolve({ latitude, longitude, accuracy });
         },

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -9,15 +9,12 @@ class Navigator {
         return reject(STATUS.ERROR_LOCATION);
       }
 
-      let locationTimeToLive = parseFloat(Storage.getItem(Storage.LOCATION_TIME_TO_LIVE));
-
-      if (locationTimeToLive) {
+      const cacheLocationMinutes = parseFloat(Storage.getItem(Storage.CACHE_LOCATION_MINUTES));
+      if (cacheLocationMinutes) {
         try {
           const lastLocation = JSON.parse(Storage.getItem(Storage.LAST_LOCATION));
-          const { latitude, longitude, accuracy, updatedAt } = lastLocation;
-
-          if(Date.now() < updatedAt + locationTimeToLive * 60 * 1000){
-            // check expiration stuff goes here
+          const { latitude, longitude, accuracy } = lastLocation;
+          if (Date.now() < parseInt(lastLocation.expiresAt)) {            // check expiration stuff goes here
             if(latitude && longitude && accuracy){
               return resolve({ latitude, longitude, accuracy });
             }
@@ -36,8 +33,11 @@ class Navigator {
 
           const { latitude, longitude, accuracy } = position.coords;
 
-          if (locationTimeToLive) {
-            const lastLocation = { latitude, longitude, accuracy, updatedAt: Date.now() };
+          if (cacheLocationMinutes) {
+            const updatedAt = Date.now();
+            const expiresAt = updatedAt + (cacheLocationMinutes * 60 * 1000); // convert to ms
+
+            const lastLocation = { latitude, longitude, accuracy, updatedAt, expiresAt };
             Storage.setItem(Storage.LAST_LOCATION, JSON.stringify(lastLocation));
           }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -34,10 +34,10 @@ class Storage {
     static get BASE_API_PATH() {
         return 'radar-base-api-path';
     }
-    static get CACHE_LOCATION_MINUTES(){
+    static get CACHE_LOCATION_MINUTES() {
         return 'radar-cache-location-minutes'
     }
-    static get LAST_LOCATION(){
+    static get LAST_LOCATION() {
         return 'radar-last-location';
     }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -34,14 +34,17 @@ class Storage {
     static get BASE_API_PATH() {
         return 'radar-base-api-path';
     }
+    static get LAST_LOCATION_TIME(){
+        return 'radar-last-location-time'
+    }
+    static get LOCATION_TIME_TO_LIVE(){
+        return 'radar-location-time-to-live'
+    }
     static get LATITUDE() {
         return 'radar-user-latitude'
     }
     static get LONGITUDE() {
         return 'radar-user-longitude'
-    }
-    static get LAST_LOCATION_TIME(){
-        return 'radar-last-location-time'
     }
     static get ACCURACY(){
         return 'radar-accuracy'

--- a/src/storage.js
+++ b/src/storage.js
@@ -34,20 +34,11 @@ class Storage {
     static get BASE_API_PATH() {
         return 'radar-base-api-path';
     }
-    static get LAST_LOCATION_TIME(){
-        return 'radar-last-location-time'
-    }
     static get LOCATION_TIME_TO_LIVE(){
         return 'radar-location-time-to-live'
     }
-    static get LATITUDE() {
-        return 'radar-user-latitude'
-    }
-    static get LONGITUDE() {
-        return 'radar-user-longitude'
-    }
-    static get ACCURACY(){
-        return 'radar-accuracy'
+    static get LAST_LOCATION(){
+        return 'radar-last-location';
     }
 
     static getStorage() {

--- a/src/storage.js
+++ b/src/storage.js
@@ -34,8 +34,8 @@ class Storage {
     static get BASE_API_PATH() {
         return 'radar-base-api-path';
     }
-    static get LOCATION_TIME_TO_LIVE(){
-        return 'radar-location-time-to-live'
+    static get CACHE_LOCATION_MINUTES(){
+        return 'radar-cache-location-minutes'
     }
     static get LAST_LOCATION(){
         return 'radar-last-location';

--- a/src/storage.js
+++ b/src/storage.js
@@ -34,6 +34,18 @@ class Storage {
     static get BASE_API_PATH() {
         return 'radar-base-api-path';
     }
+    static get LATITUDE() {
+        return 'radar-user-latitude'
+    }
+    static get LONGITUDE() {
+        return 'radar-user-longitude'
+    }
+    static get LAST_LOCATION_TIME(){
+        return 'radar-last-location-time'
+    }
+    static get ACCURACY(){
+        return 'radar-accuracy'
+    }
 
     static getStorage() {
         return (window && window.localStorage) || undefined;

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.5.0';
+export default '3.5.1-beta';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.5.1-beta';
+export default '3.5.1';


### PR DESCRIPTION
### Requirements
- [x] Linear ticked is associated with PR
- [x] Tests have been added (if not, explain why)
- [ ] Feature flags have been added and default to off in production
- [x] [Docs](https://github.com/radarlabs/documentation/tree/main/docs) have been updated (if applicable)
- [ ] Internal docs have been updated
- [x] QA is done and documented below


Difficult to write test for. Tested manually:

### QA details
*Include screenshots, responses, or steps to verify the code works as expected*

Can verify locally by setting up local sdk, or verify that it works using vercel:

https://frontend-git-boon-sdk-demo-branch-radarlabs.vercel.app/demo/js

Currently cached location time is 30 seconds. So go to link in safari, enter prompt for location.

After you can continuously reload for up to 30 seconds without being re-prompted for your location, but then after 30 seconds you'll get prompted again

I probably should have just installed loom on safari but here we are:

https://youtu.be/VU5nAQ74pyo

docs:
https://github.com/radarlabs/documentation/pull/232