### PR TITLE
Cory/inf 627 address validation web sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.6.2-beta.1",
+  "version": "3.6.2-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.6.2-beta.1",
+      "version": "3.6.2-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.6.2-beta",
+  "version": "3.6.2-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.6.2-beta",
+      "version": "3.6.2-beta.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.6.1",
+  "version": "3.6.2-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.6.0-beta",
+      "version": "3.6.2-beta",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.6.2-beta.1",
+  "version": "3.6.2-beta.2",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.6.1",
+  "version": "3.6.2-beta",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.6.2-beta",
+  "version": "3.6.2-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -9,7 +9,8 @@ class Addresses {
       number,
       postalCode,
       street,
-      unit // optional
+      unit,
+      addressLabel,
     } = addressOptions;
 
     const params = {
@@ -19,7 +20,8 @@ class Addresses {
       number,
       postalCode,
       street,
-      unit
+      unit,
+      addressLabel,
     };
 
     return Http.request('GET', 'addresses/validate', params);

--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -1,0 +1,29 @@
+import Http from '../http';
+
+class Addresses {
+  static async validateAddress(addressOptions={}) {
+    let {
+      country,
+      state,
+      city,
+      number,
+      postalCode,
+      street,
+      unit // optional
+    } = addressOptions;
+
+    const params = {
+      country,
+      state,
+      city,
+      number,
+      postalCode,
+      street,
+      unit
+    };
+
+    return Http.request('GET', 'addresses/validate', params);
+  }
+}
+
+export default Addresses;

--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -3,8 +3,8 @@ import Http from '../http';
 class Addresses {
   static async validateAddress(addressOptions={}) {
     const {
-      country,
-      state,
+      countryCode,
+      stateCode,
       city,
       number,
       postalCode,
@@ -13,8 +13,8 @@ class Addresses {
     } = addressOptions;
 
     const params = {
-      country,
-      state,
+      countryCode,
+      stateCode,
       city,
       number,
       postalCode,

--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -2,7 +2,7 @@ import Http from '../http';
 
 class Addresses {
   static async validateAddress(addressOptions={}) {
-    let {
+    const {
       country,
       state,
       city,

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -89,6 +89,7 @@ class Search {
       limit,
       layers,
       country,
+      expandUnits, // optional
     } = searchOptions;
 
     if (near?.latitude && near?.longitude) {
@@ -101,6 +102,7 @@ class Search {
       limit,
       layers,
       country,
+      expandUnits,
     };
 
     return Http.request('GET', 'search/autocomplete', params);

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -88,7 +88,8 @@ class Search {
       near,
       limit,
       layers,
-      country,
+      country, // deprecated, recommended to use countryCode
+      countryCode, 
       expandUnits, // optional
     } = searchOptions;
 
@@ -102,6 +103,7 @@ class Search {
       limit,
       layers,
       country,
+      countryCode,
       expandUnits,
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Navigator from './navigator';
 
+import Addresses from './api/addresses';
 import Context from './api/context';
 import Geocoding from './api/geocoding';
 import Routing from './api/routing';
@@ -255,6 +256,14 @@ class Radar {
     Search.autocomplete(searchOptions)
       .then((response) => {
         callback(null, { addresses: response.addresses, status: STATUS.SUCCESS }, response);
+      })
+      .catch(handleError(callback));
+  }
+
+  static validateAddress(addressOptions, callback=defaultCallback) {
+    Addresses.validateAddress(addressOptions)
+      .then((response) => {
+        callback(null, { address: response.address, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ class Radar {
   static validateAddress(addressOptions, callback=defaultCallback) {
     Addresses.validateAddress(addressOptions)
       .then((response) => {
-        callback(null, { address: response.address, status: STATUS.SUCCESS }, response);
+        callback(null, { address: response.address, result: response.result, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
   }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.6.2-beta';
+export default '3.6.2-beta.1';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.6.2-beta.1';
+export default '3.6.2-beta.2';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.6.1';
+export default '3.6.2-beta';

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -1,0 +1,68 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+import Http from '../../src/http';
+
+import Addresses from '../../src/api/addresses';
+
+describe('Addresses', () => {
+  let httpStub;
+
+  const country = 'US';
+  const state = 'NY';
+  const city = 'New York';
+  const number = '841';
+  const postalCode = '10010';
+  const street = 'Broadway';
+  const unit = '7';
+
+  const autocompleteResponse = { meta: {}, address: {} };
+
+  beforeEach(() => {
+    httpStub = sinon.stub(Http, 'request');
+  });
+
+  afterEach(() => {
+    Http.request.restore();
+  });
+
+  context('validateAddress', () => {
+    describe('params are not provided', () => {
+      it('should have undefined params and return an autocomplete response', () => {
+        httpStub.resolves(autocompleteResponse);
+
+        return Addresses.validateAddress({ number, street })
+          .then((response) => {
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: undefined, state: undefined, city: undefined, number: '841', postalCode: undefined, street: undefined, unit: undefined});
+            expect(response).to.equal(autocompleteResponse);
+          });
+      });
+    });
+
+    describe('params are provided', () => {
+      it('should return an autocomplete response', () => {
+        httpStub.resolves(autocompleteResponse);
+
+        const options = {
+          country,
+          state,
+          city,
+          number,
+          postalCode,
+          street,
+          unit
+        }
+
+        return Addresses.validateAddress(options)
+          .then((response) => {
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: 'US', state: 'NY', city: 'New York', number: '841', postalCode: '10010', street: 'Broadway', unit: '7'});
+            expect(response).to.equal(autocompleteResponse);
+          });
+      });
+    });
+  });
+});

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -20,7 +20,7 @@ describe('Addresses', () => {
   const street = 'Broadway';
   const unit = '7';
 
-  const validateResponse = { meta: {}, address: {} };
+  const validateResponse = { meta: {}, address: {}, result: {} };
 
   beforeEach(() => {
     httpStub = sinon.stub(Http, 'request');

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -37,7 +37,7 @@ describe('Addresses', () => {
 
         return Addresses.validateAddress({ number, street })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: undefined, state: undefined, city: undefined, number: '841', postalCode: undefined, street: undefined, unit: undefined});
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: undefined, state: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined});
             expect(response).to.equal(autocompleteResponse);
           });
       });

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -12,8 +12,8 @@ import Addresses from '../../src/api/addresses';
 describe('Addresses', () => {
   let httpStub;
 
-  const country = 'US';
-  const state = 'NY';
+  const countryCode = 'US';
+  const stateCode = 'NY';
   const city = 'New York';
   const number = '841';
   const postalCode = '10010';
@@ -37,7 +37,7 @@ describe('Addresses', () => {
 
         return Addresses.validateAddress({ number, street })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: undefined, state: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined});
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: undefined, stateCode: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined});
             expect(response).to.equal(validateResponse);
           });
       });
@@ -48,8 +48,8 @@ describe('Addresses', () => {
         httpStub.resolves(validateResponse);
 
         const options = {
-          country,
-          state,
+          countryCode,
+          stateCode,
           city,
           number,
           postalCode,
@@ -59,7 +59,7 @@ describe('Addresses', () => {
 
         return Addresses.validateAddress(options)
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: 'US', state: 'NY', city: 'New York', number: '841', postalCode: '10010', street: 'Broadway', unit: '7'});
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: 'US', stateCode: 'NY', city: 'New York', number: '841', postalCode: '10010', street: 'Broadway', unit: '7'});
             expect(response).to.equal(validateResponse);
           });
       });

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -15,10 +15,11 @@ describe('Addresses', () => {
   const countryCode = 'US';
   const stateCode = 'NY';
   const city = 'New York';
-  const number = '841';
   const postalCode = '10010';
+  const number = '841';
   const street = 'Broadway';
   const unit = '7';
+  const addressLabel = '841 Broadway Unit 7';
 
   const validateResponse = { meta: {}, address: {}, result: {} };
 
@@ -37,14 +38,14 @@ describe('Addresses', () => {
 
         return Addresses.validateAddress({ number, street })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: undefined, stateCode: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined});
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: undefined, stateCode: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined, addressLabel: undefined });
             expect(response).to.equal(validateResponse);
           });
       });
     });
 
     describe('params are provided', () => {
-      it('should return an autocomplete response', () => {
+      it('number, street, unit provided should return an autocomplete response', () => {
         httpStub.resolves(validateResponse);
 
         const options = {
@@ -54,15 +55,37 @@ describe('Addresses', () => {
           number,
           postalCode,
           street,
-          unit
+          unit,
+          // addressLabel,
         }
 
         return Addresses.validateAddress(options)
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: 'US', stateCode: 'NY', city: 'New York', number: '841', postalCode: '10010', street: 'Broadway', unit: '7'});
+            expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: 'US', stateCode: 'NY', city: 'New York', postalCode: '10010', number: '841', street: 'Broadway', unit: '7', addressLabel: undefined});
             expect(response).to.equal(validateResponse);
           });
       });
+    });
+
+    it('addressLabel provided should return an autocomplete response', () => {
+      httpStub.resolves(validateResponse);
+
+      const options = {
+        countryCode,
+        stateCode,
+        city,
+        postalCode,
+        // number,
+        // street,
+        // unit,
+        addressLabel,
+      }
+
+      return Addresses.validateAddress(options)
+        .then((response) => {
+          expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { countryCode: 'US', stateCode: 'NY', city: 'New York',  postalCode: '10010', addressLabel: '841 Broadway Unit 7', number: undefined, street: undefined, unit: undefined });
+          expect(response).to.equal(validateResponse);
+        });
     });
   });
 });

--- a/test/api/addresses.test.js
+++ b/test/api/addresses.test.js
@@ -20,7 +20,7 @@ describe('Addresses', () => {
   const street = 'Broadway';
   const unit = '7';
 
-  const autocompleteResponse = { meta: {}, address: {} };
+  const validateResponse = { meta: {}, address: {} };
 
   beforeEach(() => {
     httpStub = sinon.stub(Http, 'request');
@@ -33,19 +33,19 @@ describe('Addresses', () => {
   context('validateAddress', () => {
     describe('params are not provided', () => {
       it('should have undefined params and return an autocomplete response', () => {
-        httpStub.resolves(autocompleteResponse);
+        httpStub.resolves(validateResponse);
 
         return Addresses.validateAddress({ number, street })
           .then((response) => {
             expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: undefined, state: undefined, city: undefined, number: '841', postalCode: undefined, street: 'Broadway', unit: undefined});
-            expect(response).to.equal(autocompleteResponse);
+            expect(response).to.equal(validateResponse);
           });
       });
     });
 
     describe('params are provided', () => {
       it('should return an autocomplete response', () => {
-        httpStub.resolves(autocompleteResponse);
+        httpStub.resolves(validateResponse);
 
         const options = {
           country,
@@ -60,7 +60,7 @@ describe('Addresses', () => {
         return Addresses.validateAddress(options)
           .then((response) => {
             expect(Http.request).to.have.been.calledWith('GET', 'addresses/validate', { country: 'US', state: 'NY', city: 'New York', number: '841', postalCode: '10010', street: 'Broadway', unit: '7'});
-            expect(response).to.equal(autocompleteResponse);
+            expect(response).to.equal(validateResponse);
           });
       });
     });

--- a/test/api/search.test.js
+++ b/test/api/search.test.js
@@ -24,7 +24,7 @@ describe('Search', () => {
   const tags = ['geofence-tag'];
   const metadata = {'geofence-metadata-key': 'geofence-metadata-value'};
   const layers = ['venue', 'address'];
-  const country = 'US';
+  const countryCode = 'US';
   const limit = 50;
   const query = 'mock-query';
 
@@ -127,7 +127,7 @@ describe('Search', () => {
 
         return Search.autocomplete({ query })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined, expandUnits: undefined });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined, countryCode: undefined, expandUnits: undefined });
             expect(response).to.equal(autocompleteResponse);
           });
       });
@@ -139,9 +139,9 @@ describe('Search', () => {
 
         const near = { latitude, longitude };
 
-        return Search.autocomplete({ near, query, limit, layers, country })
+        return Search.autocomplete({ near, query, limit, layers, countryCode })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country, expandUnits: undefined });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], countryCode, country: undefined, expandUnits: undefined });
             expect(response).to.equal(autocompleteResponse);
           });
       });
@@ -152,9 +152,9 @@ describe('Search', () => {
         const near = { latitude, longitude };
         const expandUnits = true;
 
-        return Search.autocomplete({ near, query, limit, layers, country, expandUnits })
+        return Search.autocomplete({ near, query, limit, layers, countryCode, expandUnits })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country, expandUnits: true });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], countryCode, country: undefined, expandUnits: true });
             expect(response).to.equal(autocompleteResponse);
           });
       });

--- a/test/api/search.test.js
+++ b/test/api/search.test.js
@@ -127,7 +127,7 @@ describe('Search', () => {
 
         return Search.autocomplete({ query })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: undefined, limit: undefined, layers: undefined, country: undefined, expandUnits: undefined });
             expect(response).to.equal(autocompleteResponse);
           });
       });
@@ -141,7 +141,20 @@ describe('Search', () => {
 
         return Search.autocomplete({ near, query, limit, layers, country })
           .then((response) => {
-            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country });
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country, expandUnits: undefined });
+            expect(response).to.equal(autocompleteResponse);
+          });
+      });
+
+      it('should return an autocomplete response, with expandUnits', () => {
+        httpStub.resolves(autocompleteResponse);
+
+        const near = { latitude, longitude };
+        const expandUnits = true;
+
+        return Search.autocomplete({ near, query, limit, layers, country, expandUnits })
+          .then((response) => {
+            expect(Http.request).to.have.been.calledWith('GET', 'search/autocomplete', { query: 'mock-query', near: `${latitude},${longitude}`, limit: 50, layers: ['venue', 'address'], country, expandUnits: true });
             expect(response).to.equal(autocompleteResponse);
           });
       });


### PR DESCRIPTION
- Add `radar.ValidateAddress()` method 
- Add `expandUnits` as a param to `radar.autocomplete()`

QA: 

validateAddress() response:
![Screen Shot 2023-03-09 at 5 46 42 PM](https://user-images.githubusercontent.com/1425222/224079742-c5c00cdd-c332-4b3a-86b5-27f052fb1e2e.png)
