### PR TITLE
CORE-295 conversions to web sdk

### DIFF
--- a/demo/test.html
+++ b/demo/test.html
@@ -39,8 +39,14 @@
     </div>
 
     <div class="pl-3 pt-3">
-      <form id="custom-event" class="form-inline mb-0">
-        <button id="custom-event-btn" class="btn btn-primary">Send Custom Event</button>
+      <form id="conversion-event" class="form-inline mb-0">
+        <button id="conversion-event-btn" class="btn btn-primary">Send Conversion Event</button>
+      </form>
+    </div>
+
+    <div class="pl-3 pt-3">
+      <form id="conversion-event" class="form-inline mb-0">
+        <button id="conversion-revenue-event-btn" class="btn btn-primary">Send Conversion Revenue Event</button>
       </form>
     </div>
 
@@ -215,13 +221,27 @@
         });
       });
 
-      $("#custom-event-btn").click(function(e) {
+      $("#conversion-event-btn").click(function(e) {
         e.preventDefault();
-        const customEventData = {
-          "type": "button_click",
+        const conversionEventData = {
+          "name": "button_click",
           "metadata": {"page":"test"}
         }
-        Radar.sendEvent(customEventData, function(err, responseObj, response) {
+        Radar.logConversion(conversionEventData, function(err, responseObj, response) {
+          const event = responseObj.event;
+          console.log(err, event, response);
+        });
+      });
+
+      $("#conversion-revenue-event-btn").click(function(e) {
+        e.preventDefault();
+        const conversionEventData = {
+          "name": "purchase_click",
+          "revenue": 10,
+          "metadata": {"page":"test"}
+        }
+        console.log('here')
+        Radar.logConversion(conversionEventData, function(err, responseObj, response) {
           const event = responseObj.event;
           console.log(err, event, response);
         });

--- a/demo/test.html
+++ b/demo/test.html
@@ -240,7 +240,6 @@
           "revenue": 10,
           "metadata": {"page":"test"}
         }
-        console.log('here')
         Radar.logConversion(conversionEventData, function(err, responseObj, response) {
           const event = responseObj.event;
           console.log(err, event, response);

--- a/demo/test.html
+++ b/demo/test.html
@@ -40,13 +40,13 @@
 
     <div class="pl-3 pt-3">
       <form id="conversion-event" class="form-inline mb-0">
-        <button id="conversion-event-btn" class="btn btn-primary">Send Conversion Event</button>
+        <button id="log-conversion-event-btn" class="btn btn-primary">Send Conversion Event</button>
       </form>
     </div>
 
     <div class="pl-3 pt-3">
       <form id="conversion-event" class="form-inline mb-0">
-        <button id="conversion-revenue-event-btn" class="btn btn-primary">Send Conversion Revenue Event</button>
+        <button id="log-conversion-revenue-event-btn" class="btn btn-primary">Send Conversion Revenue Event</button>
       </form>
     </div>
 
@@ -221,7 +221,7 @@
         });
       });
 
-      $("#conversion-event-btn").click(function(e) {
+      $("#log-conversion-event-btn").click(function(e) {
         e.preventDefault();
         const conversionEventData = {
           "name": "button_click",
@@ -233,7 +233,7 @@
         });
       });
 
-      $("#conversion-revenue-event-btn").click(function(e) {
+      $("#log-conversion-revenue-event-btn").click(function(e) {
         e.preventDefault();
         const conversionEventData = {
           "name": "purchase_click",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,34 +4021,26 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -4056,17 +4048,13 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4074,75 +4062,57 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -4152,27 +4122,21 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4186,10 +4150,8 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4207,17 +4169,13 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -4227,20 +4185,16 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4248,27 +4202,21 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -4278,17 +4226,13 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4298,17 +4242,13 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4316,10 +4256,8 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -4327,10 +4265,8 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -4340,17 +4276,13 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4365,10 +4297,8 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -4387,10 +4317,8 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -4401,27 +4329,21 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -4430,10 +4352,8 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -4443,60 +4363,48 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -4504,27 +4412,21 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4537,10 +4439,8 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4553,10 +4453,8 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4566,65 +4464,49 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -4636,10 +4518,8 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4649,20 +4529,16 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -4678,34 +4554,26 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -12972,27 +12840,19 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -13000,15 +12860,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13016,81 +12872,57 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -13105,8 +12937,6 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -13118,15 +12948,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -13134,8 +12960,6 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -13143,8 +12967,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -13152,51 +12974,37 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13205,8 +13013,6 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -13214,23 +13020,17 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -13240,8 +13040,6 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -13258,8 +13056,6 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -13268,23 +13064,17 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -13294,8 +13084,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -13305,42 +13093,30 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -13348,21 +13124,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -13373,8 +13143,6 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -13388,53 +13156,37 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -13442,8 +13194,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13453,23 +13203,17 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -13482,30 +13226,22 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4021,26 +4021,34 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -4048,13 +4056,17 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4062,57 +4074,75 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -4122,21 +4152,27 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4150,8 +4186,10 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4169,13 +4207,17 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -4185,16 +4227,20 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4202,21 +4248,27 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -4226,13 +4278,17 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4242,13 +4298,17 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4256,8 +4316,10 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -4265,8 +4327,10 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -4276,13 +4340,17 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4297,8 +4365,10 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -4317,8 +4387,10 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -4329,21 +4401,27 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -4352,8 +4430,10 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -4363,48 +4443,60 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -4412,21 +4504,27 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4439,8 +4537,10 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4453,8 +4553,10 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4464,49 +4566,65 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -4518,8 +4636,10 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4529,16 +4649,20 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -4554,26 +4678,34 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -12840,19 +12972,27 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -12860,11 +13000,15 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12872,57 +13016,81 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -12937,6 +13105,8 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -12948,11 +13118,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -12960,6 +13134,8 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -12967,6 +13143,8 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -12974,37 +13152,51 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13013,6 +13205,8 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -13020,17 +13214,23 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -13040,6 +13240,8 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -13056,6 +13258,8 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -13064,17 +13268,23 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -13084,6 +13294,8 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -13093,30 +13305,42 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -13124,15 +13348,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -13143,6 +13373,8 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -13156,37 +13388,53 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -13194,6 +13442,8 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13203,17 +13453,23 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -13226,22 +13482,30 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/api/events.js
+++ b/src/api/events.js
@@ -3,13 +3,18 @@ import Storage from '../storage';
 import Device from '../device';
 
 class Events {
-  static async sendEvent(eventData={}) {
-    const { type, metadata, createdAt } = eventData;
+  static async logConversion(eventData={}) {
+    let { name, metadata, createdAt, revenue } = eventData;
 
     const deviceId = Device.getId();
     const userId = Storage.getItem(Storage.USER_ID);
+    const installId = Storage.getItem(Storage.INSTALL_ID);
 
-    return Http.request('POST', 'events', { type, metadata, deviceId, userId, createdAt })
+    if (revenue) {
+      metadata = { ...metadata, revenue };
+    }
+
+    return Http.request('POST', 'events', { type: name, metadata, deviceId, userId, installId, createdAt })
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -328,8 +328,8 @@ class Radar {
       .catch(handleError(callback));
   }
 
-  static sendEvent(eventData, callback=defaultCallback) {
-    Events.sendEvent(eventData)
+  static logConversion(eventData, callback=defaultCallback) {
+    Events.logConversion(eventData)
       .then((response) => {
         callback(null, { event: response.event, status: STATUS.SUCCESS, }, response);
       })

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.7.0';
+export default '3.7.1';

--- a/test/api/events.test.js
+++ b/test/api/events.test.js
@@ -6,7 +6,6 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 import Http from '../../src/http';
-import STATUS from '../../src/status';
 
 import Events from '../../src/api/events';
 
@@ -19,9 +18,12 @@ describe('Events', () => {
         httpStub = sinon.stub(Http, 'request');
     });
 
-    const customEventType = 'app_open';
-    const customEventMetadata = {'source':'organic'};
-    const customEventData = {customEventType, customEventMetadata}
+    const name = 'opened_app';
+    const metadata = {'source':'organic'};
+    const conversionEventData = { name, metadata };
+
+    const revenue = 10;
+    const revenueConversionEventData = { name, metadata, revenue };
 
     afterEach(() => {
         Http.request.restore();
@@ -31,10 +33,19 @@ describe('Events', () => {
         it('should return an event', () => {
           httpStub.resolves(eventResponse);
     
-          return Events.sendEvent({ customEventData })
+          return Events.logConversion({ conversionEventData })
             .then((response) => {
               expect(response).to.equal(eventResponse);
             });
         });
+
+        it('should return a revenue event', () => {
+            httpStub.resolves(eventResponse);
+      
+            return Events.logConversion({ revenueConversionEventData })
+              .then((response) => {
+                expect(response).to.equal(eventResponse);
+              });
+          });
     });
 });


### PR DESCRIPTION
There is no idea of a "session" for web sdk so we will not be doing `opened_app` here. Instead we are just making the header changes for `logConversion` with the additional capability of taking in a `revenue` param

Open Q: should we add a migration guide file?

QA:
* added tests that are passing in the CI
* added to the local browser test and it is working
<img width="1706" alt="image" src="https://user-images.githubusercontent.com/61531269/228029532-dbcd3166-33ed-419a-9a51-5b4dbfe4a2e5.png">
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/61531269/228029730-29a4005c-f249-4348-a19c-3f5695cae819.png">

