### PR TITLE
Allow backwards compatibility with Event.sendEvent and mark as deprecated

### DIFF
--- a/src/api/events.js
+++ b/src/api/events.js
@@ -16,6 +16,15 @@ class Events {
 
     return Http.request('POST', 'events', { type: name, metadata, deviceId, userId, installId, createdAt })
   }
+
+  // DEPRECATED - use logConversion
+  static async sendEvent(eventData={}) {
+    console.warn('Radar SDK: "sendEvent" is deprecated and will be removed in a future version. Use "logConversion" insetad.');
+
+    // rename type -> name
+    eventData.name = eventData.type;
+    return Events.logConversion(eventData)
+  }
 }
 
 export default Events;

--- a/src/index.js
+++ b/src/index.js
@@ -335,6 +335,15 @@ class Radar {
       })
       .catch(handleError(callback));
   }
+
+  // DEPRECATED
+  static sendEvent(eventData, callback=defaultCallback) {
+    Events.sendEvent(eventData)
+      .then((response) => {
+        callback(null, { event: response.event, status: STATUS.SUCCESS, }, response);
+      })
+      .catch(handleError(callback));
+  }
 }
 
 export default Radar;


### PR DESCRIPTION
Keeps backwards compatibility with `Event.sendEvent` and add a deprecation warning.

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/814934/228898395-8599cc0c-6e44-4677-be19-fe7e6b0b68d8.png">
