### PR TITLE
Set default mode for Trip

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -221,6 +221,9 @@ class Radar {
       Radar.clearTripOptions();
       return;
     }
+    if(!tripOptions.mode){
+      tripOptions.mode = "car";
+    }
     Storage.setItem(Storage.TRIP_OPTIONS, JSON.stringify(tripOptions));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,29 @@ class Radar {
   static startTrip(tripOptions, callback=defaultCallback) {
     Trips.startTrip(tripOptions)
       .then((response) => {
+
+        tripOptions.externalId = trip.externalId;
+        tripOptions.destinationGeofenceTag = trip.destinationGeofenceTag;
+        tripOptions.destinationGeofenceExternalId = trip.destinationGeofenceExternalId;
+        tripOptions.mode = trip.mode;
+
+        if(trip.userId){
+          tripOptions.userId = trip.userId;
+        }
+
+        if( trip.metadata ){
+          tripOptions.metadata = trip.metadata;
+        }
+
+        if( trip.approachingThreshold ){
+          tripOptions.approachingThreshold = trip.approachingThreshold;
+        }
+        if( trip.scheduledArrivalAt ){
+          tripOptions.scheduledArrivalAt = trip.scheduledArrivalAt;
+        }
+
         Radar.setTripOptions(tripOptions);
+
         callback(null, { trip: response.trip, events: response.events, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
@@ -188,7 +210,30 @@ class Radar {
   static updateTrip(tripOptions, status, callback=defaultCallback) {
     Trips.updateTrip(tripOptions, status)
       .then((response) => {
+
+        
+        tripOptions.externalId = trip.externalId;
+        tripOptions.destinationGeofenceTag = trip.destinationGeofenceTag;
+        tripOptions.destinationGeofenceExternalId = trip.destinationGeofenceExternalId;
+        tripOptions.mode = trip.mode;
+
+        if(trip.userId){
+          tripOptions.userId = trip.userId;
+        }
+
+        if( trip.metadata ){
+          tripOptions.metadata = trip.metadata;
+        }
+
+        if( trip.approachingThreshold ){
+          tripOptions.approachingThreshold = trip.approachingThreshold;
+        }
+        if( trip.scheduledArrivalAt ){
+          tripOptions.scheduledArrivalAt = trip.scheduledArrivalAt;
+        }
+  
         Radar.setTripOptions(tripOptions);
+
         callback(null, { trip: response.trip, events: response.events, status: STATUS.SUCCESS }, response);
       })
       .catch(handleError(callback));
@@ -221,6 +266,7 @@ class Radar {
       Radar.clearTripOptions();
       return;
     }
+    //Required to be set for /track
     if(!tripOptions.mode){
       tripOptions.mode = "car";
     }


### PR DESCRIPTION
When performing a track call after a trip has been started the track call retreives the tripOptions from storage. The track call requires the 'mode' to be set despite it being optional from a trip perspective. We need to set the default mode into the storage to ensure /track works.