### PR TITLE
Add option to enable high accuracy

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -3,6 +3,8 @@ const http = require('http');
 const path = require('path');
 const opn = require('opn');
 
+const PORT = 8081;
+
 http.createServer(function(req, res){
 
   const route = req.url.split('?')[0];
@@ -48,11 +50,11 @@ http.createServer(function(req, res){
       res.end();
     }
   }
-}).listen(8080);
+}).listen(PORT);
 
 setTimeout(() => {
-  console.log('Server is running on Port: 8080');
+  console.log(`Server is running on Port: ${PORT}`);
 
-  opn('http://localhost:8080')
+  opn(`http://localhost:${PORT}`)
     .catch(() => {});
 });

--- a/demo/test.html
+++ b/demo/test.html
@@ -138,7 +138,7 @@
 
         let publishableKey = $('#publishable-key').val();
 
-        Radar.initialize(publishableKey);
+        Radar.initialize(publishableKey, { enableHighAccuracy });
 
         Radar.trackOnce(function(err, responseObj, response) {
           const location = responseObj.location;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.7.2",
+  "version": "3.7.2-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.7.2",
+  "version": "3.7.2-beta.1",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Web JavaScript SDK for Radar, the location context platform",
   "homepage": "https://radar.com",
   "license": "Apache-2.0",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "main": "dist/index.js",
   "files": [
     "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ class Radar {
     }
     Storage.setItem(Storage.PUBLISHABLE_KEY, publishableKey);
 
-    const { cacheLocationMinutes } = options;
+    const { cacheLocationMinutes, enableHighAccuracy } = options;
 
     if (cacheLocationMinutes) {
       const number = Number(cacheLocationMinutes);
@@ -64,6 +64,12 @@ class Radar {
       }
     } else {
       Storage.removeItem(Storage.CACHE_LOCATION_MINUTES);
+    }
+
+    if (enableHighAccuracy) {
+      Storage.setItem(Storage.ENABLE_HIGH_ACCURACY, true);
+    } else {
+      Storage.removeItem(Storage.ENABLE_HIGH_ACCURACY);
     }
   }
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -26,6 +26,14 @@ class Navigator {
         }
       }
 
+      const enableHighAccuracy = Storage.getItem(Storage.ENABLE_HIGH_ACCURACY);
+
+      const positionOptions = {
+        maximumAge: 0,
+        timeout: 1000 * 30, // 30 seconds
+        enableHighAccuracy: Boolean(enableHighAccuracy),
+      };
+
       navigator.geolocation.getCurrentPosition(
         // success callback
         (position) => {
@@ -51,7 +59,8 @@ class Navigator {
             return reject(STATUS.ERROR_PERMISSIONS);
           }
           return reject(STATUS.ERROR_LOCATION);
-        }
+        },
+        positionOptions
       );
     });
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -37,6 +37,9 @@ class Storage {
     static get CACHE_LOCATION_MINUTES() {
         return 'radar-cache-location-minutes'
     }
+    static get ENABLE_HIGH_ACCURACY() {
+        return 'radar-enable-high-accuracy'
+    }
     static get LAST_LOCATION() {
         return 'radar-last-location';
     }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.7.1';
+export default '3.7.2';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.7.2-beta.1-beta.1';
+export default '3.7.2-beta.1';

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export default '3.7.2';
+export default '3.7.2-beta.1-beta.1';


### PR DESCRIPTION
Adds a new option `enableHighAccuracy` for [getCurrentPosition](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition).

## Usage
```js
Radar.initialize('prj_test_pk_...', { enableHighAccuracy: true });
```

## QA
**disabled (default)**
<img width="1264" alt="Screenshot 2023-06-21 at 2 36 54 PM" src="https://github.com/radarlabs/radar-sdk-js/assets/814934/4074636d-0427-4ca0-bcb4-45eaeac0774c">


**enabled**
<img width="1268" alt="Screenshot 2023-06-21 at 2 36 03 PM" src="https://github.com/radarlabs/radar-sdk-js/assets/814934/4b9b7141-0648-49ae-993b-2bd6e91e7472">