### PR TITLE
Ensure array of addresses is defined in RadarAutocompleteResponse

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -340,7 +340,7 @@ export interface RadarAutocompleteParams {
 }
 
 export interface RadarAutocompleteResponse extends RadarResponse {
-  addresses: RadarAutocompleteAddress;
+  addresses: RadarAutocompleteAddress[];
 }
 
 export interface RadarSearchPlacesParams {

--- a/test/radar.test.ts
+++ b/test/radar.test.ts
@@ -41,7 +41,9 @@ describe('Radar', () => {
 
   // geocoding
   const query = 'mock-query';
-  const addresses: RadarAddress = { geometry: { type: 'Point', coordinates: [0, 0] }, latitude, longitude };
+  const addresses: RadarAddress[] = [
+    { geometry: { type: 'Point', coordinates: [0, 0] }, latitude, longitude },
+  ];
 
   // routing
   const destination = {
@@ -364,10 +366,10 @@ describe('Radar', () => {
     });
 
     it('should call forward geocode', async () => {
-      geocodeStub.mockResolvedValue({ addresses: [addresses] });
+      geocodeStub.mockResolvedValue({ addresses });
 
       const response = await Radar.forwardGeocode({ query });
-      expect(response.addresses).toEqual([addresses]);
+      expect(response.addresses).toEqual(addresses);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/radarlabs/radar-sdk-js/issues/124

* `addressess` in `RadarAutocompleteResponse` should be an array of addresses.