### PR TITLE
hideResultsOnBlur and setOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.2",
+  "version": "4.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.8",
+  "version": "4.1.10-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.0",
+  "version": "4.1.10-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.1",
+  "version": "4.1.10-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.0",
+  "version": "4.1.10-beta.1",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.1",
+  "version": "4.1.10-beta.2",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.10-beta.2",
+  "version": "4.1.11",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.8",
+  "version": "4.1.10-beta.0",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,6 +479,7 @@ export interface RadarAutocompleteUIOptions {
   maxHeight?: string | number;
   showMarkers?: boolean;
   markerColor?: string;
+  hideResultsOnBlur?: boolean;
 }
 
 export interface RadarAutocompleteConfig extends RadarAutocompleteUIOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -463,7 +463,8 @@ export interface RadarAutocompleteUIOptions {
   container: string | HTMLElement;
   near?: string | Location; // bias for location results
   debounceMS?: number, // Debounce time in milliseconds
-  threshold?: number, // Minimum number of characters to trigger autocomplete
+  threshold?: number, // DEPRECATED(use minCharacters instead)
+  minCharacters?: number, // Minimum number of characters to trigger autocomplete
   limit?: number, // Maximum number of autocomplete results
   layers?: RadarGeocodeLayer[];
   countryCode?: string;
@@ -485,7 +486,8 @@ export interface RadarAutocompleteUIOptions {
 export interface RadarAutocompleteConfig extends RadarAutocompleteUIOptions {
   container: string | HTMLElement;
   debounceMS: number, // Debounce time in milliseconds
-  threshold: number, // Minimum number of characters to trigger autocomplete
+  threshold: number, // DEPRECATED(use minCharacters instead)
+  minCharacters: number, // Minimum number of characters to trigger autocomplete
   limit: number, // Maximum number of autocomplete results
   placeholder: string, // Placeholder text for the input field
   disabled: boolean,

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -492,10 +492,33 @@ class AutocompleteUI {
     // update height
     setHeight(this.resultsList, this.config);
 
-    // update marker color
-    const marker = this.resultsList.getElementsByClassName(CLASSNAMES.RESULTS_MARKER)[0];
-    if (marker) {
+    // update showMarkers
+    if (this.config.showMarkers === true) {
+      const marker = document.createElement('img');
+      marker.classList.add(CLASSNAMES.RESULTS_MARKER);
       marker.setAttribute('src', getMarkerIcon(this.config.markerColor));
+      const resultItems = this.resultsList.getElementsByTagName('li');
+      for (let i = 0; i < resultItems.length; i++) {
+        const currentMarker = resultItems[i].getElementsByClassName(CLASSNAMES.RESULTS_MARKER)[0];
+        if (!currentMarker) {
+          resultItems[i].prepend(marker.cloneNode());
+        }
+      }
+    }
+    if (this.config.showMarkers === false) {
+      const resultItems = this.resultsList.getElementsByTagName('li');
+      for (let i = 0; i < resultItems.length; i++) {
+        const marker = resultItems[i].getElementsByClassName(CLASSNAMES.RESULTS_MARKER)[0];
+        if (marker) {
+          marker.remove();
+        }
+      }
+    }
+
+    // update marker color
+    const marker = this.resultsList.getElementsByClassName(CLASSNAMES.RESULTS_MARKER);
+    for (let i = 0; i < marker.length; i++) {
+      marker[i].setAttribute('src', getMarkerIcon(this.config.markerColor));
     }
 
     // update hideResultsOnBlur

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -51,8 +51,9 @@ const setWidth = (input: HTMLElement, options: RadarAutocompleteUIOptions) => {
     return;
   }
 
-  // if not responsive, set fixed width
+  // if not responsive, set fixed width and unset maxWidth
   input.style.width = formatCSSValue(options.width || DEFAULT_WIDTH);
+  input.style.maxWidth = 'none';
 };
 
 const setHeight = (resultsList: HTMLElement, options: RadarAutocompleteUIOptions) => {
@@ -477,15 +478,7 @@ class AutocompleteUI {
 
   public setResponsive(responsive: boolean) {
     this.config.responsive = responsive;
-    if (responsive) {
-      this.wrapper.style.display = 'block';
-      this.inputField.style.width = '100%';
-      this.inputField.style.maxWidth = formatCSSValue(this.config.width || DEFAULT_WIDTH);
-    } else {
-      this.wrapper.style.display = 'inline-block';
-      this.inputField.style.width = formatCSSValue(this.config.width || DEFAULT_WIDTH);
-      this.inputField.style.maxWidth = 'none';
-    }
+    setWidth(this.wrapper, this.config);
     return this;
   }
 

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -491,6 +491,20 @@ class AutocompleteUI {
 
     // update height
     setHeight(this.resultsList, this.config);
+
+    // update marker color
+    const marker = this.resultsList.getElementsByClassName(CLASSNAMES.RESULTS_MARKER)[0];
+    if (marker) {
+      marker.setAttribute('src', getMarkerIcon(this.config.markerColor));
+    }
+
+    // update hideResultsOnBlur
+    if (this.config.hideResultsOnBlur === true) {
+      this.inputField.addEventListener('blur', this.close.bind(this), true);
+    } 
+    if (this.config.hideResultsOnBlur === false){
+      this.inputField.removeEventListener('blur', this.close.bind(this), true);
+    }
   }
 }
 

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -513,7 +513,7 @@ class AutocompleteUI {
 
   public setShowMarkers(showMarkers: boolean) {
     this.config.showMarkers = showMarkers;
-    if (showMarkers === true) {
+    if (showMarkers) {
       const marker = document.createElement('img');
       marker.classList.add(CLASSNAMES.RESULTS_MARKER);
       marker.setAttribute('src', getMarkerIcon(this.config.markerColor));
@@ -547,7 +547,7 @@ class AutocompleteUI {
 
   public setHideResultsOnBlur(hideResultsOnBlur: boolean) {
     this.config.hideResultsOnBlur = hideResultsOnBlur;
-    if (hideResultsOnBlur === true) {
+    if (hideResultsOnBlur) {
       this.inputField.addEventListener('blur', this.close.bind(this), true);
     } else {
       this.inputField.removeEventListener('blur', this.close.bind(this), true);

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -465,11 +465,13 @@ class AutocompleteUI {
   public setPlaceholder(placeholder: string) {
     this.config.placeholder = placeholder;
     this.inputField.placeholder = placeholder;
+    return this;
   }
 
   public setDisabled(disabled: boolean) {
     this.config.disabled = disabled;
     this.inputField.disabled = disabled;
+    return this;
   }
 
   public setResponsive(responsive: boolean) {
@@ -483,24 +485,29 @@ class AutocompleteUI {
       this.inputField.style.width = formatCSSValue(this.config.width || DEFAULT_WIDTH);
       this.inputField.style.maxWidth = 'none';
     }
+    return this;
   }
 
   public setWidth(width: number | string) {
     this.config.width = width;
     setWidth(this.wrapper, this.config);
+    return this;
   }
 
   public setMaxHeight(height: number | string) {
     this.config.maxHeight = height;
     setHeight(this.resultsList, this.config);
+    return this;
   }
 
   public setThreshold(threshold: number) {
     this.config.threshold = threshold;
+    return this;
   }
 
   public setLimit(limit: number) {
     this.config.limit = limit;
+    return this;
   }
 
   public setShowMarkers(showMarkers: boolean) {
@@ -525,6 +532,7 @@ class AutocompleteUI {
         }
       }
     }
+    return this;
   }
 
   public setMarkerColor(color: string) {
@@ -533,6 +541,7 @@ class AutocompleteUI {
     for (let i = 0; i < marker.length; i++) {
       marker[i].setAttribute('src', getMarkerIcon(color));
     }
+    return this;
   }
 
   public setHideResultsOnBlur(hideResultsOnBlur: boolean) {
@@ -542,6 +551,7 @@ class AutocompleteUI {
     } else {
       this.inputField.removeEventListener('blur', this.close.bind(this), true);
     }
+    return this;
   }
 }
 

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -462,21 +462,19 @@ class AutocompleteUI {
     }
   }
 
-  public setOptions(options: Partial<RadarAutocompleteUIOptions>) {
-    this.config = Object.assign({}, this.config, options) as RadarAutocompleteConfig;
+  public setPlaceholder(placeholder: string) {
+    this.config.placeholder = placeholder;
+    this.inputField.placeholder = placeholder;
+  }
 
-    // update input placeholder
-    if (this.inputField) {
-      this.inputField.placeholder = this.config.placeholder;
-    }
+  public setDisabled(disabled: boolean) {
+    this.config.disabled = disabled;
+    this.inputField.disabled = disabled;
+  }
 
-    // update disabled state
-    if (this.inputField) {
-      this.inputField.disabled = this.config.disabled;
-    }
-
-    // update responsive state
-    if (this.config.responsive) {
+  public setResponsive(responsive: boolean) {
+    this.config.responsive = responsive;
+    if (responsive) {
       this.wrapper.style.display = 'block';
       this.inputField.style.width = '100%';
       this.inputField.style.maxWidth = formatCSSValue(this.config.width || DEFAULT_WIDTH);
@@ -485,15 +483,29 @@ class AutocompleteUI {
       this.inputField.style.width = formatCSSValue(this.config.width || DEFAULT_WIDTH);
       this.inputField.style.maxWidth = 'none';
     }
+  }
 
-    // update width
+  public setWidth(width: number | string) {
+    this.config.width = width;
     setWidth(this.wrapper, this.config);
+  }
 
-    // update height
+  public setMaxHeight(height: number | string) {
+    this.config.maxHeight = height;
     setHeight(this.resultsList, this.config);
+  }
 
-    // update showMarkers
-    if (this.config.showMarkers === true) {
+  public setThreshold(threshold: number) {
+    this.config.threshold = threshold;
+  }
+
+  public setLimit(limit: number) {
+    this.config.limit = limit;
+  }
+
+  public setShowMarkers(showMarkers: boolean) {
+    this.config.showMarkers = showMarkers;
+    if (showMarkers === true) {
       const marker = document.createElement('img');
       marker.classList.add(CLASSNAMES.RESULTS_MARKER);
       marker.setAttribute('src', getMarkerIcon(this.config.markerColor));
@@ -504,8 +516,7 @@ class AutocompleteUI {
           resultItems[i].prepend(marker.cloneNode());
         }
       }
-    }
-    if (this.config.showMarkers === false) {
+    } else {
       const resultItems = this.resultsList.getElementsByTagName('li');
       for (let i = 0; i < resultItems.length; i++) {
         const marker = resultItems[i].getElementsByClassName(CLASSNAMES.RESULTS_MARKER)[0];
@@ -514,18 +525,21 @@ class AutocompleteUI {
         }
       }
     }
+  }
 
-    // update marker color
+  public setMarkerColor(color: string) {
+    this.config.markerColor = color;
     const marker = this.resultsList.getElementsByClassName(CLASSNAMES.RESULTS_MARKER);
     for (let i = 0; i < marker.length; i++) {
-      marker[i].setAttribute('src', getMarkerIcon(this.config.markerColor));
+      marker[i].setAttribute('src', getMarkerIcon(color));
     }
+  }
 
-    // update hideResultsOnBlur
-    if (this.config.hideResultsOnBlur === true) {
+  public setHideResultsOnBlur(hideResultsOnBlur: boolean) {
+    this.config.hideResultsOnBlur = hideResultsOnBlur;
+    if (hideResultsOnBlur === true) {
       this.inputField.addEventListener('blur', this.close.bind(this), true);
-    } 
-    if (this.config.hideResultsOnBlur === false){
+    } else {
       this.inputField.removeEventListener('blur', this.close.bind(this), true);
     }
   }

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -452,13 +452,13 @@ class AutocompleteUI {
     this.wrapper.remove();
   }
 
-  public setNear(near: string | Location) {
-    if (near) {
-      if (typeof near === 'string') {
-        this.near = near;
-      } else {
-        this.near = `${near.latitude},${near.longitude}`;
-      }
+  public setNear(near: string | Location | undefined | null) {
+    if (near === undefined || near === null) {
+      this.near = undefined;
+    } else if (typeof near === 'string') {
+      this.near = near;
+    } else {
+      this.near = `${near.latitude},${near.longitude}`;
     }
     return this;
   }

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -29,6 +29,7 @@ const defaultAutocompleteOptions: RadarAutocompleteUIOptions = {
   responsive: true,
   disabled: false,
   showMarkers: true,
+  hideResultsOnBlur: true,
 };
 
 // determine whether to use px or CSS string
@@ -162,8 +163,10 @@ class AutocompleteUI {
 
     // setup event listeners
     this.inputField.addEventListener('input', this.handleInput.bind(this));
-    this.inputField.addEventListener('blur', this.close.bind(this), true);
     this.inputField.addEventListener('keydown', this.handleKeyboardNavigation.bind(this));
+    if (this.config.hideResultsOnBlur){
+      this.inputField.addEventListener('blur', this.close.bind(this), true);
+    }
 
     Logger.debug(`AutocompleteUI iniailized with options: ${JSON.stringify(this.config)}`);
   }

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -461,6 +461,37 @@ class AutocompleteUI {
       }
     }
   }
+
+  public setOptions(options: Partial<RadarAutocompleteUIOptions>) {
+    this.config = Object.assign({}, this.config, options) as RadarAutocompleteConfig;
+
+    // update input placeholder
+    if (this.inputField) {
+      this.inputField.placeholder = this.config.placeholder;
+    }
+
+    // update disabled state
+    if (this.inputField) {
+      this.inputField.disabled = this.config.disabled;
+    }
+
+    // update responsive state
+    if (this.config.responsive) {
+      this.wrapper.style.display = 'block';
+      this.inputField.style.width = '100%';
+      this.inputField.style.maxWidth = formatCSSValue(this.config.width || DEFAULT_WIDTH);
+    } else {
+      this.wrapper.style.display = 'inline-block';
+      this.inputField.style.width = formatCSSValue(this.config.width || DEFAULT_WIDTH);
+      this.inputField.style.maxWidth = 'none';
+    }
+
+    // update width
+    setWidth(this.wrapper, this.config);
+
+    // update height
+    setHeight(this.resultsList, this.config);
+  }
 }
 
 export default AutocompleteUI;

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -460,6 +460,7 @@ class AutocompleteUI {
         this.near = `${near.latitude},${near.longitude}`;
       }
     }
+    return this;
   }
 
   public setPlaceholder(placeholder: string) {

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -53,7 +53,7 @@ const setWidth = (input: HTMLElement, options: RadarAutocompleteUIOptions) => {
 
   // if not responsive, set fixed width and unset maxWidth
   input.style.width = formatCSSValue(options.width || DEFAULT_WIDTH);
-  input.style.maxWidth = 'none';
+  input.style.removeProperty('max-width');
 };
 
 const setHeight = (resultsList: HTMLElement, options: RadarAutocompleteUIOptions) => {

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -23,7 +23,7 @@ const ARIA = {
 const defaultAutocompleteOptions: RadarAutocompleteUIOptions = {
   container: 'autocomplete',
   debounceMS: 200, // Debounce time in milliseconds
-  threshold: 3, // Minimum number of characters to trigger autocomplete
+  minCharacters: 3, // Minimum number of characters to trigger autocomplete
   limit: 8, // Maximum number of autocomplete results
   placeholder: 'Search address', // Placeholder text for the input field
   responsive: true,
@@ -101,6 +101,12 @@ class AutocompleteUI {
     this.results = [];
     this.highlightedIndex = -1;
 
+    // set threshold alias
+    if (this.config.threshold !== undefined) {
+      this.config.minCharacters = this.config.threshold;
+      Logger.warn('AutocompleteUI option "threshold" is deprecated, use "minCharacters" instead.');
+    }
+
     if (options.near) {
       if (typeof options.near === 'string') {
         this.near = options.near;
@@ -165,7 +171,7 @@ class AutocompleteUI {
     // setup event listeners
     this.inputField.addEventListener('input', this.handleInput.bind(this));
     this.inputField.addEventListener('keydown', this.handleKeyboardNavigation.bind(this));
-    if (this.config.hideResultsOnBlur){
+    if (this.config.hideResultsOnBlur) {
       this.inputField.addEventListener('blur', this.close.bind(this), true);
     }
 
@@ -175,7 +181,7 @@ class AutocompleteUI {
   public handleInput() {
     // Fetch autocomplete results and display them
     const query = this.inputField.value;
-    if (query.length < this.config.threshold) {
+    if (query.length < this.config.minCharacters) {
       return;
     }
 
@@ -494,8 +500,9 @@ class AutocompleteUI {
     return this;
   }
 
-  public setThreshold(threshold: number) {
-    this.config.threshold = threshold;
+  public setMinCharacters(minCharacters: number) {
+    this.config.minCharacters = minCharacters;
+    this.config.threshold = minCharacters;
     return this;
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.1.10-beta.2';
+export default '4.1.11';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.1.10-beta.0';
+export default '4.1.10-beta.1';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.1.10-beta.1';
+export default '4.1.10-beta.2';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.1.8';
+export default '4.1.10-beta.0';


### PR DESCRIPTION
Added `hideResultsOnBlur` option so that the results list persist on click away.

Also, added `setOptions` function so that the autocomplete element does not have to be completely rerendered everytime an option changes.

These are needed for internal usage

### QA
https://www.loom.com/share/2084a71a836041ebbed533a88fe7a27c