### PR TITLE
More resilient readme updates when bumping version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.1.7/radar.min.js"></script>
+<script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.11/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.11/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.11/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.11/radar.min.js"></script>
   </head>
 
   <body>

--- a/scripts/bump-version.cjs
+++ b/scripts/bump-version.cjs
@@ -36,7 +36,7 @@ lockfile.version = version;
 fs.writeFileSync('./package-lock.json', JSON.stringify(lockfile, null, 2) + '\n');
 
 // update versions in readme
-const reg = new RegExp(`js\.radar\.com\/v([^/]+)\/`, 'g');
+const reg = new RegExp(`js.radar.com\/v([^/]+)\/`, 'g');
 const readme = fs.readFileSync('./README.md').toString();
 fs.writeFileSync('./README.md', readme.replace(reg, `js.radar.com/v${version}/`));
 

--- a/scripts/bump-version.cjs
+++ b/scripts/bump-version.cjs
@@ -36,8 +36,8 @@ lockfile.version = version;
 fs.writeFileSync('./package-lock.json', JSON.stringify(lockfile, null, 2) + '\n');
 
 // update versions in readme
-const reg = new RegExp(`v${current}`, 'g');
+const reg = new RegExp(`js\.radar\.com\/v([^/]+)\/`, 'g');
 const readme = fs.readFileSync('./README.md').toString();
-fs.writeFileSync('./README.md', readme.replace(reg, `v${version}`));
+fs.writeFileSync('./README.md', readme.replace(reg, `js.radar.com/v${version}/`));
 
 console.log('Updated to', version);


### PR DESCRIPTION
* Updates README with latest SDK version in examples
* Make the `bump-version` script more resilient to version updates (does not need to have an exact match to previous version)