### PR TITLE
send time zone to POST /track

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.1.12/radar.min.js"></script>
+<script src="https://js.radar.com/v4.1.13/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.12/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.12/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.13/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.13/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.12/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.12/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.13/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.13/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.1.12/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.1.12/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.1.13/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.1.13/radar.min.js"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/src/api/track.ts
+++ b/src/api/track.ts
@@ -42,6 +42,13 @@ class TrackAPI {
     const deviceType = params.deviceType || 'Web';
     const description = params.description || Storage.getItem(Storage.DESCRIPTION);
 
+    let timeZone;
+    try {
+      timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch (err: any) {
+      Logger.warn(`Error getting time zone: ${err.message}`);
+    }
+
     // save userId for trip tracking
     if (!userId) {
       Logger.warn('userId not provided for trackOnce.');
@@ -75,6 +82,7 @@ class TrackAPI {
       stopped: true,
       userId,
       tripOptions,
+      timeZone,
     };
 
     const response: any = await Http.request({

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.1.12';
+export default '4.1.13';


### PR DESCRIPTION
sends IANA time zone identifier for the browser's time zone, such as `"America/New_York"` or `"Europe/Paris"`, to `POST /track`