### PR TITLE
Radar map UI kit refactor

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -458,12 +458,16 @@ export interface RadarMapOptions extends maplibregl.MapOptions {
   container: string | HTMLElement;
 }
 
-export interface RadarMarkerOptions {
-  color?: string;
+export interface RadarMarkerImage {
+  url: string;
+  width: string;
+  height: string;
+}
+
+export interface RadarMarkerOptions extends maplibregl.MarkerOptions {
   text?: string;
   html?: string;
-  element?: HTMLElement;
-  scale?: number;
+  image?: RadarMarkerImage;
 }
 
 export interface RadarAutocompleteUIOptions {

--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -1,0 +1,160 @@
+import maplibregl from 'maplibre-gl';
+
+import RadarMarker from './RadarMarker';
+
+import Config from '../config';
+import Http from '../http';
+import Logger from '../logger';
+import RadarLogoControl from './RadarLogoControl';
+
+import type { RadarOptions, RadarMapOptions } from '../types';
+
+const DEFAULT_STYLE = 'radar-default-v1';
+
+const RADAR_STYLES = [
+  'radar-default-v1',
+  'radar-light-v1',
+  'radar-dark-v1',
+];
+
+const defaultMaplibreOptions: Partial<maplibregl.MapOptions> = {
+  minZoom: 1,
+  maxZoom: 20,
+  attributionControl: false,
+  dragRotate: false,
+  touchPitch: false,
+  maplibreLogo: false,
+};
+
+const uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+
+const createStyleURL = (options: RadarOptions, style: string = DEFAULT_STYLE) => (
+  `${options.host}/maps/styles/${style}?publishableKey=${options.publishableKey}`
+);
+
+/** Check if style is a Radar style or a custom style */
+const isRadarStyle = (style: string) => {
+  return RADAR_STYLES.includes(style) || uuidRegex.test(style)
+};
+
+/** Use formatted style URL if using one of Radar's out-of-the-box styles or is a Radar custom style */
+const getStyle = (options: RadarOptions, mapOptions: RadarMapOptions) => {
+  const style = mapOptions.style;
+
+  if (!style || (typeof style === 'string' && isRadarStyle(style))) {
+    return createStyleURL(options, style);
+  }
+
+  return mapOptions.style;
+};
+
+class RadarMap extends maplibregl.Map {
+  _customMarkerRawSvg: string | undefined;
+  _markers: RadarMarker[] = [];
+
+  constructor(mapOptions: RadarMapOptions) {
+    const config = Config.get();
+
+    if (!config.publishableKey) {
+      Logger.warn('publishableKey not set. Call Radar.initialize() with key before creating a new map.');
+    }
+
+    // configure maplibre options
+    const style = getStyle(config, mapOptions);
+    const maplibreOptions: maplibregl.MapOptions = Object.assign({},
+      defaultMaplibreOptions,
+      mapOptions,
+      { style },
+    );
+    Logger.debug(`initialize map with options: ${JSON.stringify(maplibreOptions)}`);
+
+    // custom request handler for Radar styles
+    maplibreOptions.transformRequest = (url, resourceType) => {
+      let radarStyleURL = url;
+      if (resourceType === 'Style' && isRadarStyle(url)) {
+        radarStyleURL = createStyleURL(config, url);
+      }
+
+      if (mapOptions.transformRequest) {
+        return mapOptions.transformRequest(radarStyleURL, resourceType);
+      }
+
+      return { url: radarStyleURL };
+    };
+
+    super(maplibreOptions);
+
+    const container = this.getContainer();
+
+    if (!container.style.width && !container.style.height) {
+      Logger.warn('map container does not have a set "width" or "height"');
+    }
+
+    // add radar logo
+    const radarLogo = new RadarLogoControl();
+    this.addControl(radarLogo, 'bottom-left');
+
+    // add attribution
+    const attribution = new maplibregl.AttributionControl({ compact: false });
+    this.addControl(attribution, 'bottom-right');
+
+    // add zoom controls
+    const nav = new maplibregl.NavigationControl({ showCompass: false });
+    this.addControl(nav, 'bottom-right');
+
+    // handle map resize actions
+    const onResize = () => {
+      const attrib = document.querySelector('.maplibregl-ctrl-attrib');
+      if (attrib) {
+        const width = this.getContainer().clientWidth;
+        if (width < 380) {
+          attrib.classList.add('hidden');
+        } else {
+          attrib.classList.remove('hidden');
+        }
+      }
+    };
+    this.on('resize', onResize);
+    this.on('load', onResize);
+
+    const onStyleLoad = async () => {
+      this._customMarkerRawSvg = undefined;
+      const style = this.getStyle();
+
+      const customMarkers = (style.metadata as any)?.['radar:customMarkers'];
+      if (Array.isArray(customMarkers) && customMarkers.length > 0) {
+        const customMarker = customMarkers[0]; // only support one custom marker for now
+        try {
+          const markerRawSvg = await Http.request({
+            method: 'GET',
+            versioned: false,
+            path: `maps/markers/${customMarker.id}`,
+            headers: {
+              'Content-Type': 'image/svg+xml',
+            },
+          });
+          this._customMarkerRawSvg = markerRawSvg.data;
+        } catch (err) {
+          Logger.warn(`Error getting custom marker: ${customMarker.id} - using default marker.`);
+        }
+      }
+
+      // set markers if necessary
+      this._markers.forEach((marker) => {
+        if (this._customMarkerRawSvg && !marker._image) {
+          // set custom marker
+          marker._element.innerHTML = this._customMarkerRawSvg;
+        } else {
+          const markerOptions = marker.getOptions();
+          const newMarker = new RadarMarker(markerOptions); // get default element
+
+          // set default element
+          marker._element.innerHTML = newMarker._element.innerHTML;
+        }
+      });
+    }
+    this.on('styledata', onStyleLoad);
+  }
+};
+
+export default RadarMap;

--- a/src/ui/RadarMarker.ts
+++ b/src/ui/RadarMarker.ts
@@ -1,0 +1,86 @@
+import maplibregl from 'maplibre-gl';
+
+import type RadarMap from './RadarMap';
+
+import type { RadarMarkerImage, RadarMarkerOptions } from '../types';
+
+const defaultMarkerOptions: maplibregl.MarkerOptions = {
+  color: '#000257',
+};
+
+class RadarMarker extends maplibregl.Marker {
+  _map!: RadarMap;
+  _image?: RadarMarkerImage;
+
+  constructor(markerOptions: RadarMarkerOptions) {
+    const maplibreOptions: maplibregl.MarkerOptions = Object.assign({}, defaultMarkerOptions);
+
+    if (markerOptions.color) {
+      maplibreOptions.color = markerOptions.color;
+    }
+    if (markerOptions.element) {
+      maplibreOptions.element = markerOptions.element;
+    }
+    if (markerOptions.scale) {
+      maplibreOptions.scale = markerOptions.scale;
+    }
+    if (markerOptions.image) {
+      const element = document.createElement('div');
+      element.style.backgroundImage = `url(${markerOptions.image.url})`;
+      element.style.width = markerOptions.image.width;
+      element.style.height = markerOptions.image.height;
+
+      maplibreOptions.element = element;
+    }
+
+    super(maplibreOptions);
+
+    if (markerOptions.image) {
+      this._image = markerOptions.image;
+    }
+
+    // set popup text or HTML
+    if (markerOptions.text) {
+      const popup = new maplibregl.Popup({ offset: 35 }).setText(markerOptions.text);
+      this.setPopup(popup);
+    } else if (markerOptions.html) {
+      const popup = new maplibregl.Popup({ offset: 35 }).setHTML(markerOptions.html);
+      this.setPopup(popup);
+    }
+  }
+
+  addTo(map: RadarMap) {
+    if (map._customMarkerRawSvg && !this._image) {
+      this._element.innerHTML = map._customMarkerRawSvg;
+    }
+    map._markers.push(this);
+    return super.addTo(map);
+  }
+
+  remove() {
+    if (this._map) {
+      this._map._markers = this._map._markers.filter((marker) => marker !== this);
+    }
+    return super.remove();
+  }
+
+  getOptions(): RadarMarkerOptions {
+    const markerOptions: RadarMarkerOptions = {
+      // TODO: element: marker.getElement(),
+      image: this._image,
+      color: this._color,
+      scale: this._scale,
+      offset: this.getOffset(),
+      anchor: this._anchor,
+      draggable: this.isDraggable(),
+      clickTolerance: this._clickTolerance,
+      rotation: this.getRotation(),
+      rotationAlignment: this.getRotationAlignment(),
+      pitchAlignment: this.getPitchAlignment()
+    }
+
+    return markerOptions;
+  }
+}
+
+export default RadarMarker;

--- a/src/ui/map.ts
+++ b/src/ui/map.ts
@@ -1,219 +1,25 @@
-import maplibregl, { Marker, MarkerOptions } from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
 
-import Config from '../config';
-import Http from '../http';
-import Logger from '../logger';
-import RadarLogoControl from './RadarLogoControl';
+import RadarMap from './RadarMap';
+import RadarMarker from './RadarMarker';
 
-import type { RadarOptions, RadarMapOptions, RadarMarkerOptions } from '../types';
-
-const DEFAULT_STYLE = 'radar-default-v1';
-
-const RADAR_STYLES = [
-  'radar-default-v1',
-  'radar-light-v1',
-  'radar-dark-v1',
-];
-
-const RADAR_LOGO_URL = 'https://api.radar.io/maps/static/images/logo.svg';
-
-const defaultMaplibreOptions: Partial<maplibregl.MapOptions> = {
-  minZoom: 1,
-  maxZoom: 20,
-  attributionControl: false,
-  dragRotate: false,
-  touchPitch: false,
-  maplibreLogo: false,
-};
-
-const defaultMarkerOptions: Partial<maplibregl.MarkerOptions> = {
-  color: '#000257',
-};
-
-const uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
-
-const createStyleURL = (options: RadarOptions, style: string = DEFAULT_STYLE) => (
-  `${options.host}/maps/styles/${style}?publishableKey=${options.publishableKey}`
-);
-
-const getMarkerOptions = (marker: Marker): MarkerOptions => {
-  const markerOptions: MarkerOptions = {
-    // element: marker.getElement(),
-    color: marker._color,
-    scale: marker._scale,
-    offset: marker.getOffset(),
-    anchor: marker._anchor,
-    draggable: marker.isDraggable(),
-    clickTolerance: marker._clickTolerance,
-    rotation: marker.getRotation(),
-    rotationAlignment: marker.getRotationAlignment(),
-    pitchAlignment: marker.getPitchAlignment()
-  }
-
-  return markerOptions;
-}
-
-/** Check if style is a Radar style or a custom style */
-const isRadarStyle = (style: string) => {
-  return RADAR_STYLES.includes(style) || uuidRegex.test(style)
-};
-
-/** Use formatted style URL if using one of Radar's out-of-the-box styles or is a Radar custom style */
-const getStyle = (options: RadarOptions, mapOptions: RadarMapOptions) => {
-  const style = mapOptions.style;
-
-  if (!style || (typeof style === 'string' && isRadarStyle(style))) {
-    return createStyleURL(options, style);
-  }
-
-  return mapOptions.style;
-};
+import type { RadarMapOptions, RadarMarkerOptions } from '../types';
 
 class MapUI {
-  private static customMarkerRawSvg: string | undefined;
-  private static markers: Marker[] = [];
-
   public static getMapLibre() {
     return maplibregl;
   }
 
-  public static createMap(mapOptions: RadarMapOptions): maplibregl.Map {
-    const options = Config.get();
+  public static createMap(mapOptions: RadarMapOptions): RadarMap {
+    const radarMap = new RadarMap(mapOptions);
 
-    if (!options.publishableKey) {
-      Logger.warn('publishableKey not set. Call Radar.initialize() with key before creating a new map.');
-    }
-
-    // configure maplibre options
-    const style = getStyle(options, mapOptions);
-    const maplibreOptions: maplibregl.MapOptions = Object.assign({},
-      defaultMaplibreOptions,
-      mapOptions,
-      { style },
-    );
-    Logger.debug(`initialize map with options: ${JSON.stringify(maplibreOptions)}`);
-
-    // set container
-    maplibreOptions.container = mapOptions.container;
-
-    // custom request handler for Radar styles
-    maplibreOptions.transformRequest = (url, resourceType) => {
-      if (resourceType === 'Style' && isRadarStyle(url)) {
-        const radarStyleURL = createStyleURL(options, url);
-        return { url: radarStyleURL };
-      } else {
-        return { url };
-      }
-    };
-
-    // create map
-    const map = new maplibregl.Map(maplibreOptions);
-    const container = map.getContainer();
-
-    if (!container.style.width && !container.style.height) {
-      Logger.warn('map container does not have a set "width" or "height"');
-    }
-
-    // add radar logo
-    const radarLogo = new RadarLogoControl();
-    map.addControl(radarLogo, 'bottom-left');
-
-    // add attribution
-    const attribution = new maplibregl.AttributionControl({ compact: false });
-    map.addControl(attribution, 'bottom-right');
-
-    // add zoom controls
-    const nav = new maplibregl.NavigationControl({ showCompass: false });
-    map.addControl(nav, 'bottom-right');
-
-    // handle map resize actions
-    const onResize = () => {
-      const attrib = document.querySelector('.maplibregl-ctrl-attrib');
-      if (attrib) {
-        const width = map.getContainer().clientWidth;
-        if (width < 380) {
-          attrib.classList.add('hidden');
-        } else {
-          attrib.classList.remove('hidden');
-        }
-      }
-    };
-
-    const onStyleLoad = async () => {
-      MapUI.customMarkerRawSvg = undefined;
-      const style = map.getStyle();
-
-      const customMarkers = (style.metadata as any)?.['radar:customMarkers'];
-      if (Array.isArray(customMarkers) && customMarkers.length > 0) {
-        const customMarker = customMarkers[0]; // only support one custom marker for now
-        try {
-          const markerRawSvg = await Http.request({
-            method: 'GET',
-            versioned: false,
-            path: `maps/markers/${customMarker.id}`,
-            headers: {
-              'Content-Type': 'image/svg+xml',
-            },
-          });
-          MapUI.customMarkerRawSvg = markerRawSvg.data;
-        } catch (err) {
-          Logger.warn(`Error getting custom marker: ${customMarker.id} - using default marker.`);
-        }
-      }
-
-      // set markers if necessary
-      for (let i = 0; i < MapUI.markers.length; i++) {
-        if (MapUI.customMarkerRawSvg) {
-          // set custom marker
-          MapUI.markers[i]._element.innerHTML = MapUI.customMarkerRawSvg;
-        } else {
-          const markerOptions = getMarkerOptions(MapUI.markers[i]);
-          const newMarker = new Marker(markerOptions); // get default element
-
-          // set default element
-          MapUI.markers[i]._element.innerHTML = newMarker._element.innerHTML;
-        }
-      }
-    }
-    map.on('resize', onResize);
-    map.on('load', onResize);
-    map.on('styledata', onStyleLoad);
-
-    return map;
+    return radarMap;
   }
 
-  public static createMarker(markerOptions: RadarMarkerOptions = {}): maplibregl.Marker {
-    const maplibreOptions: maplibregl.MarkerOptions = Object.assign({}, defaultMarkerOptions);
+  public static createMarker(markerOptions: RadarMarkerOptions = {}): RadarMarker {
+    const radarMarker = new RadarMarker(markerOptions);
 
-    // has a custom marker
-    if (MapUI.customMarkerRawSvg) {
-      maplibreOptions.element = document.createElement('div');
-      maplibreOptions.element.innerHTML = MapUI.customMarkerRawSvg;
-    }
-
-    if (markerOptions.color) {
-      maplibreOptions.color = markerOptions.color;
-    }
-    if (markerOptions.element) {
-      maplibreOptions.element = markerOptions.element;
-    }
-    if (markerOptions.scale) {
-      maplibreOptions.scale = markerOptions.scale;
-    }
-
-    const marker = new maplibregl.Marker(maplibreOptions);
-
-    // set popup text or HTML
-    if (markerOptions.text) {
-      const popup = new maplibregl.Popup({ offset: 35 }).setText(markerOptions.text);
-      marker.setPopup(popup);
-    } else if (markerOptions.html) {
-      const popup = new maplibregl.Popup({ offset: 35 }).setHTML(markerOptions.html);
-      marker.setPopup(popup);
-    }
-
-    MapUI.markers.push(marker);
-    return marker;
+    return radarMarker;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "target": "es5",
+    "target": "es2016",
     "module": "es2015",
     "declaration": true,
     "outDir": "./dist",


### PR DESCRIPTION
uses an inheritance pattern instead of wrapping the `maplibre-gl Map` in helper functions. This allows us to more closely develop features on top of the `maplibre-gl Map` class instance