### PR TITLE
Map initalization `language` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
+<script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
   </head>
 
   <body>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.3.0-beta.0/radar.min.js"></script>
+<script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.1/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.1/radar.min.js"></script>
   </head>
 
   <body>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
+<script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.2/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.2/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
   </head>
 
   <body>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
+<script src="https://js.radar.com/v4.3.0-beta.4/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.4/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.4/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.3.0-beta.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.3.0-beta.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.3.0-beta.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.3.0-beta.4/radar.min.js"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.1",
+  "version": "4.3.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.3",
+  "version": "4.3.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.0",
+  "version": "4.3.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.0",
+  "version": "4.3.0-beta.1",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.3",
+  "version": "4.3.0-beta.4",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.1",
+  "version": "4.3.0-beta.2",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.3.0-beta.2",
+  "version": "4.3.0-beta.3",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -128,15 +128,6 @@ class Navigator {
       });
     });
   }
-
-  public static async getLanguage() {
-    if (!navigator || !navigator.language) {
-      Logger.warn('navigator.language is not available');
-      return undefined;
-    }
-
-    return navigator.language;
-  }
 }
 
 export default Navigator;

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -128,6 +128,15 @@ class Navigator {
       });
     });
   }
+
+  public static async getLanguage() {
+    if (!navigator || !navigator.language) {
+      Logger.warn('navigator.language is not available');
+      return undefined;
+    }
+
+    return navigator.language;
+  }
 }
 
 export default Navigator;

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,7 +460,7 @@ export interface RadarSearchGeofencesResponse extends RadarResponse {
 }
 
 export interface RadarMapOptions extends Omit<maplibregl.MapOptions, 'transformRequest'> {
-  locale?: string;
+  language?: string;
 }
 
 export interface RadarMarkerImage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,7 +460,7 @@ export interface RadarSearchGeofencesResponse extends RadarResponse {
 }
 
 export interface RadarMapOptions extends Omit<maplibregl.MapOptions, 'transformRequest'> {
-  container: string | HTMLElement;
+  locale?: string;
 }
 
 export interface RadarMarkerImage {

--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -90,7 +90,6 @@ class RadarMap extends maplibregl.Map {
         'Authorization': config.publishableKey,
         'X-Radar-Device-Type': 'Web',
         'X-Radar-SDK-Version': SDK_VERSION,
-        'X-Radar-Device-Language': Navigator.getLanguage(),
       };
       if (typeof config.getRequestHeaders === 'function') {
         headers = Object.assign(headers, config.getRequestHeaders());

--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -28,8 +28,8 @@ const defaultMaplibreOptions: Partial<maplibregl.MapOptions> = {
 
 const createStyleURL = (options: RadarOptions, mapOptions: RadarMapOptions) => {
   let url = `${options.host}/maps/styles/${mapOptions.style}?publishableKey=${options.publishableKey}`
-  if (mapOptions.locale) {
-    url += `&locale=${mapOptions.locale}`
+  if (mapOptions.language) {
+    url += `&language=${mapOptions.language}`
   }
   return url
 };
@@ -85,6 +85,7 @@ class RadarMap extends maplibregl.Map {
         'Authorization': config.publishableKey,
         'X-Radar-Device-Type': 'Web',
         'X-Radar-SDK-Version': SDK_VERSION,
+        'X-Radar-Device-Language': navigator.language,
       };
       if (typeof config.getRequestHeaders === 'function') {
         headers = Object.assign(headers, config.getRequestHeaders());

--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -75,7 +75,11 @@ class RadarMap extends maplibregl.Map {
     );
     Logger.debug(`initialize map with options: ${JSON.stringify(maplibreOptions)}`);
 
-    (maplibreOptions as maplibregl.MapOptions).transformRequest = (url) => {
+    (maplibreOptions as maplibregl.MapOptions).transformRequest = (url, resourceType) => {
+      // this handles when a style is switched
+      if (resourceType === 'Style' && isRadarStyle(url)) {
+        url = createStyleURL(config, { ...maplibreOptions, style: url });
+      }
 
       let headers = {
         'Authorization': config.publishableKey,

--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -6,6 +6,7 @@ import RadarLogoControl from './RadarLogoControl';
 
 import Config from '../config';
 import Logger from '../logger';
+import Navigator from '../navigator';
 
 import type { RadarOptions, RadarMapOptions } from '../types';
 
@@ -89,7 +90,7 @@ class RadarMap extends maplibregl.Map {
         'Authorization': config.publishableKey,
         'X-Radar-Device-Type': 'Web',
         'X-Radar-SDK-Version': SDK_VERSION,
-        'X-Radar-Device-Language': navigator.language,
+        'X-Radar-Device-Language': Navigator.getLanguage(),
       };
       if (typeof config.getRequestHeaders === 'function') {
         headers = Object.assign(headers, config.getRequestHeaders());

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.3.0-beta.2';
+export default '4.3.0-beta.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.3.0-beta.3';
+export default '4.3.0-beta.4';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.3.0-beta.1';
+export default '4.3.0-beta.2';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.3.0-beta.0';
+export default '4.3.0-beta.1';


### PR DESCRIPTION
Adds the map option `language` to configure map language. This only works for Radar map styles as it searchs and replaces for the expression `["get", "radar:name_client_language"]`.

Also sends up the header `X-Radar-Device-Language` with every style request which grabs from `navigator.language`. This is so that the server can figure out how to transform the style appropriately given the browser language.