### PR TITLE
Allow map event propagation on marker click

### DIFF
--- a/src/ui/RadarMarker.ts
+++ b/src/ui/RadarMarker.ts
@@ -145,10 +145,6 @@ class RadarMarker extends maplibregl.Marker {
     const element = this.getElement();
     if (element) {
       element.addEventListener('click', (e) => {
-        e.stopPropagation(); // stop propagation to map
-        if (this._popup) {
-          this.togglePopup();
-        }
         this.fire('click', e);
       });
     }

--- a/src/ui/RadarMarker.ts
+++ b/src/ui/RadarMarker.ts
@@ -7,12 +7,27 @@ import type RadarMap from './RadarMap';
 
 import type { RadarMarkerOptions } from '../types';
 
+class RadarMarkerMouseEvent {
+  type: 'click';
+  target: RadarMarker;
+  originalEvent: MouseEvent;
+  lngLat: maplibregl.LngLat;
+  point: maplibregl.Point2D;
+
+  constructor(type: 'click', marker: RadarMarker, originalEvent: MouseEvent) {
+    this.target = marker;
+    this.originalEvent = originalEvent;
+    this.point = marker._pos;
+    this.lngLat = marker.getLngLat();
+    this.type = type;
+  }
+}
+
 interface ImageOptions {
   url?: string;
   width?: number | string;
   height?: number | string;
 }
-
 
 const createImageElement = (options: ImageOptions) => {
   const element = document.createElement('img');
@@ -145,7 +160,7 @@ class RadarMarker extends maplibregl.Marker {
     const element = this.getElement();
     if (element) {
       element.addEventListener('click', (e) => {
-        this.fire('click', e);
+        this.fire('click', new RadarMarkerMouseEvent('click', this, e));
       });
     }
   }


### PR DESCRIPTION
Tries to keep the event payload more in line with [maplibre mouse events](https://github.com/maplibre/maplibre-gl-js/blob/350064ecfe6c4bd074a19b5e7195cf010bede168/src/ui/events.ts#L475-L532). 

Since we're extending their `Marker` class, there's gonna be limitations as towards how flexible this event + event payload can be. Mainly, it's gonna be really tricky trying to stop event propagation to the map itself since all of maplibre's event are built using the map event listener. For example, they determine which element was "clicked" by checking if the event target contains the map element AND a marker in their own marker click handler. Their popup click handler is also tied to the map click event so we ideally we are not interfering with it.