### PR TITLE
Autocomplete fixes (race condition, prevent autofill, style fixes)

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types';
 
 class SearchAPI {
-  static async autocomplete(params: RadarAutocompleteParams): Promise<RadarAutocompleteResponse> {
+  static async autocomplete(params: RadarAutocompleteParams, requestId?: string): Promise<RadarAutocompleteResponse> {
     const options = Config.get();
 
     let {
@@ -45,6 +45,7 @@ class SearchAPI {
         expandUnits,
         mailable,
       },
+      requestId,
     });
 
     const autocompleteRes = {

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -263,7 +263,7 @@ class AutocompleteUI {
       onRequest(params);
     }
 
-    const { addresses } = await SearchAPI.autocomplete(params);
+    const { addresses } = await SearchAPI.autocomplete(params, 'autocomplete-ui');
     return addresses;
   }
 

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -168,6 +168,9 @@ class AutocompleteUI {
       this.container.appendChild(this.wrapper);
     }
 
+    // disable browser autofill
+    this.inputField.setAttribute('autocomplete', 'off');
+
     // set aria roles
     this.inputField.setAttribute('role', 'combobox');
     this.inputField.setAttribute('aria-controls', CLASSNAMES.RESULTS_LIST);

--- a/styles/radar.css
+++ b/styles/radar.css
@@ -211,3 +211,6 @@
 .maplibregl-ctrl-attrib.hidden {
   display: none !important;
 }
+.maplibregl-popup-close-button:focus-visible {
+  outline: none;
+}

--- a/styles/radar.css
+++ b/styles/radar.css
@@ -185,12 +185,12 @@
 }
 
 .radar-powered a {
-  text-decoration: none;
-  color: var(--radar-gray6);
+  text-decoration: none !important;
+  color: var(--radar-gray6) !important;
 }
 
 .radar-powered a:visited {
-  color: var(--radar-gray6);
+  color: var(--radar-gray6) !important;
 }
 
 .radar-powered #radar-powered-logo {


### PR DESCRIPTION
* Fixes a race-condition on autocomplete requests
* Disable browser autofill for address autocomplete
* Autocomplete style fixes

## Race Condition
There is a subtle race condition in the autocomplete component that exists when a previous request completes before the latest request. In the scenario where multiple requests are in-flight, the first request to complete sets the results (regardless if the user has typed more characters). The fix is to cancel any in-flight requests when another is issued.

Note: responses are manually throttled down in the examples to demonstrate the issue

#### Race Condition:
https://github.com/user-attachments/assets/69927fc6-688e-4e57-a02d-a80784d0c662



#### Fix:
https://github.com/user-attachments/assets/1821f72a-ea65-4ace-8f07-7e085e857674

