### PR TITLE
Use auth header for publishable key

### DIFF
--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -38,11 +38,11 @@ const defaultFitMarkersOptions: maplibregl.FitBoundsOptions = {
 const createStyleURL = (options: RadarOptions, mapOptions: RadarMapOptions) => {
   const style = mapOptions.style || DEFAULT_STYLE;
 
-  let url = `${options.host}/maps/styles/${style}?publishableKey=${options.publishableKey}`
+  let url = `${options.host}/maps/styles/${style}`
   if (mapOptions.language) {
-    url += `&language=${mapOptions.language}`
+    url += `?language=${mapOptions.language}`
   }
-  return url
+  return url;
 };
 
 // check if style is a Radar style or a custom style


### PR DESCRIPTION
Rely on the `Authorization` header to provide publishable key instead of query param for maps.

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/e64c7f1e-f2aa-4c4e-a77a-a4f2bd566b35">
