### PR TITLE
Deprecate countryCode in favor of country param for autocomplete

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -20,6 +20,7 @@ class SearchAPI {
       near,
       limit,
       layers,
+      country,
       countryCode,
       expandUnits,
       mailable,
@@ -33,6 +34,11 @@ class SearchAPI {
       }
     }
 
+    // replace countryCode with country
+    if (countryCode && !country) {
+      country = countryCode;
+    }
+
     const response: any = await Http.request({
       method: 'GET',
       path: 'search/autocomplete',
@@ -41,7 +47,7 @@ class SearchAPI {
         near,
         limit,
         layers,
-        countryCode,
+        country,
         expandUnits,
         mailable,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,8 @@ export interface RadarAutocompleteParams {
   near?: Location | string;
   limit?: number;
   layers?: RadarGeocodeLayer[];
+  country?: string;
+  /** @deprecated use country */
   countryCode?: string;
   /** @deprecated this is always true, regardless of the value passed here */
   expandUnits?: boolean;
@@ -535,10 +537,13 @@ export interface RadarAutocompleteUIOptions {
   container: string | HTMLElement;
   near?: string | Location; // bias for location results
   debounceMS?: number, // Debounce time in milliseconds
-  threshold?: number, // DEPRECATED(use minCharacters instead)
+  /** deprecated use minCharacters */
+  threshold?: number,
   minCharacters?: number, // Minimum number of characters to trigger autocomplete
   limit?: number, // Maximum number of autocomplete results
   layers?: RadarGeocodeLayer[];
+  country?: string;
+  /** @deprecated use country */
   countryCode?: string;
   expandUnits?: boolean;
   mailable?: boolean;

--- a/src/ui/autocomplete.ts
+++ b/src/ui/autocomplete.ts
@@ -247,13 +247,17 @@ class AutocompleteUI {
   }
 
   public async fetchResults(query: string) {
-    const { limit, layers, countryCode, expandUnits, mailable, onRequest } = this.config;
+    let { limit, layers, country, countryCode, expandUnits, mailable, onRequest } = this.config;
+
+    if (countryCode && !country) {
+      country = countryCode;
+    }
 
     const params: RadarAutocompleteParams = {
       query,
       limit,
       layers,
-      countryCode,
+      country,
       expandUnits,
       mailable,
     }


### PR DESCRIPTION
* Deprecates `countryCode` for autocomplete
* Adds `country` param (countryCode will fallback to country for backwards compatibility)