### PR TITLE
Update params and types for geocoding and search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.4.3/radar.min.js"></script>
+<script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.3/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.3/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
   </head>
 
   <body>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
+<script src="https://js.radar.com/v4.4.4/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.4-beta.0/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.4-beta.0/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.4/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.4/radar.min.js"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.4-beta.0",
+  "version": "4.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.3",
+  "version": "4.4.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.3",
+  "version": "4.4.4-beta.0",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.4-beta.0",
+  "version": "4.4.4",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/src/api/geocoding.ts
+++ b/src/api/geocoding.ts
@@ -13,7 +13,7 @@ class Geocoding {
   static async forwardGeocode(params: RadarForwardGeocodeParams): Promise<RadarGeocodeResponse> {
     const options = Config.get();
 
-    const { query, layers, country, lang} = params;
+    const { query, layers, country, lang } = params;
 
     const response: any = await Http.request({
       method: 'GET',

--- a/src/api/geocoding.ts
+++ b/src/api/geocoding.ts
@@ -13,7 +13,7 @@ class Geocoding {
   static async forwardGeocode(params: RadarForwardGeocodeParams): Promise<RadarGeocodeResponse> {
     const options = Config.get();
 
-    const { query, layers, country } = params;
+    const { query, layers, country, lang} = params;
 
     const response: any = await Http.request({
       method: 'GET',
@@ -22,6 +22,7 @@ class Geocoding {
         query,
         layers,
         country,
+        lang,
       },
     });
 

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -23,6 +23,7 @@ class SearchAPI {
       countryCode,
       expandUnits,
       mailable,
+      lang,
     } = params;
 
     // near can be provided as a string or Location object
@@ -44,6 +45,7 @@ class SearchAPI {
         countryCode,
         expandUnits,
         mailable,
+        lang,
       },
       requestId,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -548,17 +548,12 @@ export interface RadarPolygonOptions {
     'border-opacity'?: number;
   },
 }
-export interface RadarAutocompleteUIOptions {
+export interface RadarAutocompleteUIOptions extends Omit<RadarAutocompleteParams, 'query'> {
   container: string | HTMLElement;
-  near?: string | Location; // bias for location results
   debounceMS?: number, // Debounce time in milliseconds
-  threshold?: number, // DEPRECATED(use minCharacters instead)
+  /** @deprecated use minCharacters instead */
+  threshold?: number,
   minCharacters?: number, // Minimum number of characters to trigger autocomplete
-  limit?: number, // Maximum number of autocomplete results
-  layers?: RadarGeocodeLayer[];
-  countryCode?: string;
-  expandUnits?: boolean;
-  mailable?: boolean;
   placeholder?: string, // Placeholder text for the input field
   onSelection?: (selection: any) => void,
   onRequest?: (params: RadarAutocompleteParams) => void,
@@ -574,7 +569,6 @@ export interface RadarAutocompleteUIOptions {
 }
 
 export interface RadarAutocompleteConfig extends RadarAutocompleteUIOptions {
-  container: string | HTMLElement;
   debounceMS: number, // Debounce time in milliseconds
   threshold: number, // DEPRECATED(use minCharacters instead)
   minCharacters: number, // Minimum number of characters to trigger autocomplete

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,6 +270,7 @@ export type RadarGeocodeLayer =
   | 'address'
   | 'postalCode'
   | 'locality'
+  | 'neighborhood'
   | 'county'
   | 'state'
   | 'country'
@@ -302,8 +303,22 @@ export interface RadarAddress {
   street?: string;
 }
 
+export interface RadarTimeZone {
+  id: string;
+  name: string;
+  code: string;
+  currentTime: string;
+  utcOffset: number;
+  dstOffset: number;
+}
+
 export interface RadarAutocompleteAddress extends RadarAddress {
   unit?: string;
+}
+
+export interface RadarGeocodeAddress extends RadarAddress {
+  unit?: string;
+  timeZone?: RadarTimeZone;
 }
 
 export type RadarValidationRecordType = 'S' | 'R' | 'P' | 'M' | 'H' | 'G' | 'F' | undefined;
@@ -325,6 +340,7 @@ export interface RadarForwardGeocodeParams {
   query: string;
   layers?: RadarGeocodeLayer[];
   country?: string;
+  lang?: string;
 }
 
 export interface RadarReverseGeocodeParams {
@@ -333,13 +349,13 @@ export interface RadarReverseGeocodeParams {
   layers?: RadarGeocodeLayer[];
 }
 
-export interface RadarGeocodeResponse  extends RadarResponse {
-  addresses: RadarAddress[];
+export interface RadarGeocodeResponse extends RadarResponse {
+  addresses: RadarGeocodeAddress[];
 }
 
 export interface RadarIPGeocodeResponse extends RadarResponse {
   ip: string;
-  address?: RadarAddress;
+  address?: RadarGeocodeAddress;
   proxy?: boolean;
 }
 
@@ -352,6 +368,7 @@ export interface RadarAutocompleteParams {
   /** @deprecated this is always true, regardless of the value passed here */
   expandUnits?: boolean;
   mailable?: boolean;
+  lang?: string;
 }
 
 export interface RadarAutocompleteResponse extends RadarResponse {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.4.3';
+export default '4.4.4-beta.0';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.4.4-beta.0';
+export default '4.4.4';


### PR DESCRIPTION
- adds support for the `lang` param for `autocomplete` and `forwardGeocode`
- adds `timeZone` property in response for `forwardGeocode`, `reverseGeocode`, `ipGeocode`
- adds neighborhood layer type to `RadarGeocodeLayer`