### PR TITLE
prevent /config call on multiple initializations

### DIFF
--- a/demo/views/display-a-map.hbs
+++ b/demo/views/display-a-map.hbs
@@ -35,6 +35,8 @@
     $('#map').show();
 
     Radar.initialize(publishableKey, { debug: true });
+    Radar.initialize(publishableKey, { debug: true });
+    Radar.initialize(publishableKey, { debug: true });
 
     // prevent duplicate maps from rendering over each other
     if (map) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -58,6 +58,10 @@ class Radar {
       throw new RadarPublishableKeyError('Secret keys are not allowed. Please use your Radar publishable key.');
     }
 
+    if (Config.isInitialized()) {
+      Logger.error('Radar.initialize() called more than once.');
+    }
+
     // store settings in global config
     const live = isLiveKey(publishableKey);
     const logLevel = live ? 'error' : 'info';
@@ -79,11 +83,15 @@ class Radar {
       Logger.debug('using options', options);
     }
 
-    // NOTE(jasonl): this allows us to run jest tests
-    // without having to mock the ConfigAPI.getConfig call
-    if (!(window as any)?.RADAR_TEST_ENV) {
-      ConfigAPI.getConfig();
+    if (!Config.isInitialized()) { // only call getConfig on first initialization
+      // NOTE(jasonl): this allows us to run jest tests
+      // without having to mock the ConfigAPI.getConfig call
+      if (!(window as any)?.RADAR_TEST_ENV) {
+        ConfigAPI.getConfig();
+      }
     }
+
+    Config.setInitialized();
   }
 
   public static clear() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import type { RadarOptions } from './types';
 
 class Config {
   static options: RadarOptions;
+  static initialized: boolean = false;
 
   static defaultOptions = {
     live: false,
@@ -13,6 +14,14 @@ class Config {
 
   public static setup(options: RadarOptions = {}) {
     Config.options = options;
+  }
+
+  public static setInitialized() {
+    Config.initialized = true;
+  }
+
+  public static isInitialized(): boolean {
+    return Config.initialized;
   }
 
   public static get(): RadarOptions {


### PR DESCRIPTION
* Warn on multiple initializations and prevent multiple calls to `/config`

## Before
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/b2865822-039a-4086-9f04-b331961d285e">

## After
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/389e4e60-adce-46d6-8a6d-5b1f2cf254bd">
