### PR TITLE
Catch `trackVerified()` errors in `startTrackingVerified()`, change location timeout to 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Radar.initialize('prj_test_pk_...', { /* options */ });
 
 Add the following script in your `html` file
 ```html
-<script src="https://js.radar.com/v4.4.7/radar.min.js"></script>
+<script src="https://js.radar.com/v4.4.8/radar.min.js"></script>
 ```
 
 Then initialize the Radar SDK
@@ -73,8 +73,8 @@ To create a map, first initialize the Radar SDK with your publishable key. Then 
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.8/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.8/radar.min.js"></script>
   </head>
 
   <body>
@@ -98,8 +98,8 @@ To create an autocomplete input, first initialize the Radar SDK with your publis
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.8/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.8/radar.min.js"></script>
   </head>
 
   <body>
@@ -130,8 +130,8 @@ To power [geofencing](https://radar.com/documentation/geofencing/overview) exper
 ```html
 <html>
   <head>
-    <link href="https://js.radar.com/v4.4.7/radar.css" rel="stylesheet">
-    <script src="https://js.radar.com/v4.4.7/radar.min.js"></script>
+    <link href="https://js.radar.com/v4.4.8/radar.css" rel="stylesheet">
+    <script src="https://js.radar.com/v4.4.8/radar.min.js"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "type": "module",

--- a/src/api/verify.ts
+++ b/src/api/verify.ts
@@ -116,8 +116,13 @@ class VerifyAPI {
 
   static async startTrackingVerified(params: RadarStartTrackingVerifiedParams) {
     const doTrackVerified = async () => {
-      const trackRes = await this.trackVerified(params);
-
+      let trackRes;
+      try {
+        trackRes = await this.trackVerified(params);
+      } catch {
+        
+      }
+      
       const { interval } = params;
 
       let expiresIn = 0;

--- a/src/api/verify.ts
+++ b/src/api/verify.ts
@@ -119,8 +119,8 @@ class VerifyAPI {
       let trackRes;
       try {
         trackRes = await this.trackVerified(params);
-      } catch {
-        
+      } catch (err: any) {
+        Logger.error(`trackVerified error: ${err.message}`);
       }
       
       const { interval } = params;

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -11,7 +11,7 @@ interface PositionOptionOverrides {
 
 const DEFAULT_POSITION_OPTIONS: PositionOptions = {
   maximumAge: 0,
-  timeout: 1000 * 30, // 30 seconds
+  timeout: 1000 * 10, // 10 seconds
   enableHighAccuracy: true,
 };
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '4.4.7';
+export default '4.4.8';


### PR DESCRIPTION
- change location timeout to 10 seconds to match mobile SDKs
- catch `trackVerified()` errors in `startTrackingVerified()` to ensure tracking doesn't stop
- bump version to `4.4.8`