### PR TITLE
Add top level `passed` attribute to user object.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,7 @@ export interface RadarUser {
   dma?: RadarRegion;
   postalCode?: RadarRegion;
   fraud?: RadarFraud;
+  passed?: boolean;
 }
 
 export interface RadarTrackResponse extends RadarResponse {


### PR DESCRIPTION
Without the `passed` attribute declared on the interface Typescript will crash when attempting to access that attribute for fraud custoemrs.