### PR TITLE
Update maplibre-gl Peer Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "maplibre-gl": "^2.4.0 || ^3.0.0 || ^4.0.0"
+        "maplibre-gl": "^2.4.0 || ^3.0.0 || ^4.0.0 || ^5.0.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/geojson": "^7946.0.10"
   },
   "peerDependencies": {
-    "maplibre-gl": "^2.4.0 || ^3.0.0 || ^4.0.0"
+    "maplibre-gl": "^2.4.0 || ^3.0.0 || ^4.0.0 || ^5.0.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Allow maplibre 5.0.1 for Globe support