### PR TITLE
FRA-1076: add optional reason to track params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "4.5.2",
+      "version": "4.5.0",
       "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "radar-sdk-js",
-      "version": "4.5.0",
+      "version": "4.5.2",
       "license": "ISC",
       "dependencies": {
         "@types/geojson": "^7946.0.10"

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface RadarTrackParams {
   tripOptions?: RadarTripOptions;
   desiredAccuracy?: 'high' | 'medium' | 'low';
   fraud?: boolean;
+  reason?: string;
 }
 
 export interface RadarTrackVerifiedParams {


### PR DESCRIPTION
Adding an optional `reason` param to track params

Use Case:
```
Radar.track({ userId: 'test-user-id', reason: 'test-reason'})
```

Including reasons in the trackOnce request:
<img width="379" alt="Screenshot 2025-05-13 at 1 04 20 PM" src="https://github.com/user-attachments/assets/d6c6f87f-dfdf-4b3e-94f0-e3975a82be3a" />

Not including reasons:
<img width="813" alt="Screenshot 2025-05-13 at 1 53 36 PM" src="https://github.com/user-attachments/assets/29802a09-5edc-4d55-9cfd-2dbd596b8660" />
