### PR TITLE
Remove `minZoom` default

### DIFF
--- a/src/ui/RadarMap.ts
+++ b/src/ui/RadarMap.ts
@@ -33,7 +33,6 @@ const defaultRadarMapOptions: Partial<RadarMapOptions> = {
 };
 
 const defaultMaplibreOptions: Partial<maplibregl.MapOptions> = {
-  minZoom: 1,
   maxZoom: 20,
   attributionControl: false,
   dragRotate: false,


### PR DESCRIPTION
Fix for issue mentioned here: https://github.com/maplibre/maplibre-gl-js/issues/5932

<img width="906" alt="image" src="https://github.com/user-attachments/assets/2b0e710e-9435-4207-bcc8-f1f79a6046ed" />
