### PR TITLE
fix(http): proper RFC 3986 encoding in GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Radar.initialize({ publishableKey: 'prj_test_pk_...' });
 Add the following to your HTML:
 
 ```html
-<script src="https://js.radar.com/v5.1.0/radar.min.js"></script>
+<script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
 
 <script>
   Radar.initialize({ publishableKey: 'prj_test_pk_...' });
@@ -134,7 +134,7 @@ the core SDK first, then any plugins you need:
 <link href="https://js.radar.com/maps/v1.0.0/radar-maps.css" rel="stylesheet" />
 <link href="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.css" rel="stylesheet" />
 
-<script src="https://js.radar.com/v5.1.0/radar.min.js"></script>
+<script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
 <script src="https://js.radar.com/maps/v1.0.0/radar-maps.min.js"></script>
 <script src="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.min.js"></script>
 <script src="https://js.radar.com/fraud/v1.0.0/radar-fraud.min.js"></script>
@@ -151,7 +151,7 @@ by ID or element reference.
 <html>
   <head>
     <link href="https://js.radar.com/maps/v1.0.0/radar-maps.css" rel="stylesheet" />
-    <script src="https://js.radar.com/v5.1.0/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
     <script src="https://js.radar.com/maps/v1.0.0/radar-maps.min.js"></script>
   </head>
 
@@ -178,7 +178,7 @@ by ID or element reference.
 <html>
   <head>
     <link href="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.css" rel="stylesheet" />
-    <script src="https://js.radar.com/v5.1.0/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
     <script src="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.min.js"></script>
   </head>
 
@@ -211,7 +211,7 @@ are needed for geofencing.
 ```html
 <html>
   <head>
-    <script src="https://js.radar.com/v5.1.0/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "license": "ISC",

--- a/src/http.ts
+++ b/src/http.ts
@@ -112,7 +112,7 @@ class Http {
       const params = new URLSearchParams(Object.entries(filtered).map(([k, v]) => [k, String(v)]));
       // URLSearchParams serializes spaces as '+' (application/x-www-form-urlencoded)
       // a query string is part of a URI, so encode per RFC 3986 (%20)
-      // the only differnce is really how spaces are handled between the two protocols
+      // the only difference is really how spaces are handled between the two protocols
       const qs = params.toString().replace(/\+/g, '%20');
       if (qs) {
         url = `${url}?${qs}`;

--- a/src/http.ts
+++ b/src/http.ts
@@ -110,7 +110,10 @@ class Http {
 
     if (method === 'GET') {
       const params = new URLSearchParams(Object.entries(filtered).map(([k, v]) => [k, String(v)]));
-      const qs = params.toString();
+      // URLSearchParams serializes spaces as '+' (application/x-www-form-urlencoded)
+      // a query string is part of a URI, so encode per RFC 3986 (%20)
+      // the only differnce is really how spaces are handled between the two protocols
+      const qs = params.toString().replace(/\+/g, '%20');
       if (qs) {
         url = `${url}?${qs}`;
       }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '5.1.0';
+export default '5.1.1';

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -131,9 +131,93 @@ describe('Http', () => {
       const response = await Http.request({ method: 'GET', path: 'geocode/forward', data });
       const request = getRequest();
 
-      expect(request.url).toContain('?query=841+Broadway');
+      expect(request.url).toContain('?query=841%20Broadway');
 
       expect(response.code).toEqual(200);
+    });
+
+    it('should encode spaces as %20 (RFC 3986), NOT + (application/x-www-form-urlencoded)', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'a b c' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=a%20b%20c');
+      expect(request.url).not.toContain('+');
+    });
+
+    it('should preserve a literal + as %2B', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: '1+1 = 2' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=1%2B1%20%3D%202');
+    });
+
+    it('should percent-encode reserved delimiters inside a value', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'a&b=c#d?e/f' } });
+      const request = getRequest();
+
+      // & = # ? / inside a value must be encoded so they can't split the query
+      expect(request.url).toContain('?query=a%26b%3Dc%23d%3Fe%2Ff');
+    });
+
+    it('should percent-encode a literal % as %25', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: '50%' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=50%25');
+    });
+
+    it('should UTF-8 percent-encode non-ASCII characters', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'café 北京' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=caf%C3%A9%20%E5%8C%97%E4%BA%AC');
+    });
+
+    it('should encode parameter names, not just values', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { 'a b': 'x' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?a%20b=x');
+    });
+
+    it('should leave RFC 3986 unreserved characters unencoded', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'Abc-9_.xZ' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=Abc-9_.xZ');
+    });
+
+    it('should separate multiple params with a literal & while encoding each value', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'a b', near: '40.1,-74.2' } });
+      const request = getRequest();
+
+      expect(request.url).toContain('?query=a%20b&near=40.1%2C-74.2');
+    });
+
+    it('should over-encode ~ and leave * literal (both RFC 3986-valid)', async () => {
+      mockRequest(200, successResponse);
+
+      await Http.request({ method: 'GET', path: 'geocode/forward', data: { query: 'a~b*c' } });
+      const request = getRequest();
+
+      // URLSearchParams over-encodes the unreserved ~ (harmless) and keeps * literal
+      expect(request.url).toContain('?query=a%7Eb*c');
     });
 
     it('should not append querystring of no params', async () => {


### PR DESCRIPTION
## Problem
reason = "Game Launch" is picked up by Verify apps as "Game+Launch"

we were implicitly encoding our GET query params through `application/x-www-form-urlencoded` rather than `RFC 3986`

when you do something like:
```
> params = new URLSearchParams({ reason: 'game launch' })
URLSearchParams { 'reason' => 'game launch' }
> params.toString()
'reason=game+launch'
```
we'll have to replace `+` with `%20`. this is the main deviation between the two encoding protocols