### PR TITLE
MAPS-2581: Add autocomplete session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Radar.initialize({ publishableKey: 'prj_test_pk_...' });
 Add the following to your HTML:
 
 ```html
-<script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
+<script src="https://js.radar.com/v5.1.2/radar.min.js"></script>
 
 <script>
   Radar.initialize({ publishableKey: 'prj_test_pk_...' });
@@ -134,7 +134,7 @@ the core SDK first, then any plugins you need:
 <link href="https://js.radar.com/maps/v1.0.0/radar-maps.css" rel="stylesheet" />
 <link href="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.css" rel="stylesheet" />
 
-<script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
+<script src="https://js.radar.com/v5.1.2/radar.min.js"></script>
 <script src="https://js.radar.com/maps/v1.0.0/radar-maps.min.js"></script>
 <script src="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.min.js"></script>
 <script src="https://js.radar.com/fraud/v1.0.0/radar-fraud.min.js"></script>
@@ -151,7 +151,7 @@ by ID or element reference.
 <html>
   <head>
     <link href="https://js.radar.com/maps/v1.0.0/radar-maps.css" rel="stylesheet" />
-    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.2/radar.min.js"></script>
     <script src="https://js.radar.com/maps/v1.0.0/radar-maps.min.js"></script>
   </head>
 
@@ -178,7 +178,7 @@ by ID or element reference.
 <html>
   <head>
     <link href="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.css" rel="stylesheet" />
-    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.2/radar.min.js"></script>
     <script src="https://js.radar.com/autocomplete/v1.1.0/radar-autocomplete.min.js"></script>
   </head>
 
@@ -211,7 +211,7 @@ are needed for geofencing.
 ```html
 <html>
   <head>
-    <script src="https://js.radar.com/v5.1.1/radar.min.js"></script>
+    <script src="https://js.radar.com/v5.1.2/radar.min.js"></script>
   </head>
 
   <body>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,14 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  // core tests live in test/, plugin tests live in packages/<plugin>/test/
   testMatch: ['<rootDir>/test/**/*.test.ts', '<rootDir>/packages/*/test/**/*.test.ts'],
   setupFilesAfterEnv: ['./test/mock-data/globals.ts'],
   moduleNameMapper: {
     '\\.css$': '<rootDir>/test/mock-data/styles.js',
-    // plugin sources import the core SDK by package name; resolve to source so the suite
-    // runs against an unbuilt tree (node_modules/radar-sdk-js points at dist/)
+    // Plugins import core as 'radar-sdk-js', which normally resolves through node_modules
+    // to the built dist/. Point it at src/ instead so `npm test` works without running a
+    // build first. tsconfig.test.json has the matching entry for the typechecker.
     '^radar-sdk-js$': '<rootDir>/src/index.ts',
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,13 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  testMatch: ['<rootDir>/test/**/*.test.ts', '<rootDir>/packages/*/test/**/*.test.ts'],
   setupFilesAfterEnv: ['./test/mock-data/globals.ts'],
   moduleNameMapper: {
     '\\.css$': '<rootDir>/test/mock-data/styles.js',
+    // plugin sources import the core SDK by package name; resolve to source so the suite
+    // runs against an unbuilt tree (node_modules/radar-sdk-js points at dist/)
+    '^radar-sdk-js$': '<rootDir>/src/index.ts',
   },
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -11033,7 +11033,7 @@
     },
     "packages/autocomplete": {
       "name": "@radarlabs/plugin-autocomplete",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "radar-sdk-js": "file:../..",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radar-sdk-js",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Web Javascript SDK for Radar, location infrastructure for mobile and web apps.",
   "homepage": "https://radar.com",
   "license": "ISC",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radarlabs/plugin-autocomplete",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Autocomplete UI plugin for radar-sdk-js",
   "license": "ISC",
   "repository": {

--- a/packages/autocomplete/src/autocomplete.ts
+++ b/packages/autocomplete/src/autocomplete.ts
@@ -90,7 +90,7 @@ class AutocompleteUI {
   isOpen: boolean;
   results: RadarAutocompleteAddress[];
   /** UUID grouping this widget's autocomplete requests and clickthroughs into one session */
-  sessionToken: string;
+  readonly sessionToken: string;
   /** `x-radar-request-id` of the response that produced the currently displayed results */
   private _lastRequestId?: string;
   private _highlightedIndex: number;

--- a/packages/autocomplete/src/autocomplete.ts
+++ b/packages/autocomplete/src/autocomplete.ts
@@ -632,18 +632,19 @@ class AutocompleteUI {
     }
     this.inputField.value = inputValue;
 
-    const onSelection = this.config.onSelection;
-    if (onSelection) {
-      onSelection(result);
-    }
-
     if (this._lastRequestId) {
-      // fire-and-forget: autocompleteClick never rejects, so no need to await or catch
+      // reported before onSelection: that callback is consumer code, and a throw from it
+      // must not swallow the clickthrough. fire-and-forget -- autocompleteClick never rejects.
       void this.ctx.apis.Search.autocompleteClick({
         sessionToken: this.sessionToken,
         requestId: this._lastRequestId,
         idx: index,
       });
+    }
+
+    const onSelection = this.config.onSelection;
+    if (onSelection) {
+      onSelection(result);
     }
 
     // Return focus to input after selection

--- a/packages/autocomplete/src/autocomplete.ts
+++ b/packages/autocomplete/src/autocomplete.ts
@@ -640,6 +640,11 @@ class AutocompleteUI {
         requestId: this._lastRequestId,
         idx: index,
       });
+    } else {
+      Logger.warn(
+        'Could not report autocomplete selection: the autocomplete response carried no request ID. ' +
+          'Check that the x-radar-request-id response header is exposed to the browser.',
+      );
     }
 
     const onSelection = this.config.onSelection;

--- a/packages/autocomplete/src/autocomplete.ts
+++ b/packages/autocomplete/src/autocomplete.ts
@@ -1,4 +1,5 @@
 import { RadarAutocompleteContainerNotFound } from './errors';
+import generateUUID from './uuid';
 
 import type { RadarAutocompleteUIOptions, RadarAutocompleteConfig } from './types';
 import type { RadarAutocompleteAddress, RadarAutocompleteParams, Location, RadarPluginContext } from 'radar-sdk-js';
@@ -88,6 +89,10 @@ class AutocompleteUI {
   config: RadarAutocompleteConfig;
   isOpen: boolean;
   results: RadarAutocompleteAddress[];
+  /** UUID grouping this widget's autocomplete requests and clickthroughs into one session */
+  sessionToken: string;
+  /** `x-radar-request-id` of the response that produced the currently displayed results */
+  private _lastRequestId?: string;
   private _highlightedIndex: number;
   debouncedFetchResults: (query: string) => Promise<RadarAutocompleteAddress[] | null>;
   near?: string;
@@ -152,6 +157,7 @@ class AutocompleteUI {
     }, this.config.debounceMS);
     this.results = [];
     this._highlightedIndex = -1;
+    this.sessionToken = generateUUID();
 
     // set threshold alias
     if (this.config.threshold !== undefined) {
@@ -388,6 +394,7 @@ class AutocompleteUI {
       mailable,
       lang,
       postalCode,
+      sessionToken: this.sessionToken,
     };
 
     if (this.near) {
@@ -398,7 +405,8 @@ class AutocompleteUI {
       onRequest(params);
     }
 
-    const { addresses } = await apis.Search.autocomplete(params, 'autocomplete-ui');
+    const { addresses, requestId } = await apis.Search.autocomplete(params, 'autocomplete-ui');
+    this._lastRequestId = requestId;
     return addresses;
   }
 
@@ -627,6 +635,15 @@ class AutocompleteUI {
     const onSelection = this.config.onSelection;
     if (onSelection) {
       onSelection(result);
+    }
+
+    if (this._lastRequestId) {
+      // fire-and-forget: autocompleteClick never rejects, so no need to await or catch
+      void this.ctx.apis.Search.autocompleteClick({
+        sessionToken: this.sessionToken,
+        requestId: this._lastRequestId,
+        idx: index,
+      });
     }
 
     // Return focus to input after selection

--- a/packages/autocomplete/src/uuid.ts
+++ b/packages/autocomplete/src/uuid.ts
@@ -1,0 +1,25 @@
+/**
+ * generate a random v4 UUID
+ *
+ * NOTE(binhrobles): mirrors the generator private to the core SDK's device.ts, rather than
+ * being shared through RadarPluginContext. The plugin is versioned separately, so widening
+ * the published plugin contract for a 12-line crypto shim is the more expensive trade.
+ *
+ * @returns a newly generated UUID
+ */
+const generateUUID = (): string => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  // fallback for older browsers
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80; // variant 10
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+export default generateUUID;

--- a/packages/autocomplete/src/uuid.ts
+++ b/packages/autocomplete/src/uuid.ts
@@ -1,9 +1,8 @@
 /**
  * generate a random v4 UUID
  *
- * NOTE(binhrobles): mirrors the generator private to the core SDK's device.ts, rather than
- * being shared through RadarPluginContext. The plugin is versioned separately, so widening
- * the published plugin contract for a 12-line crypto shim is the more expensive trade.
+ * NOTE: mirrors the generator private to the core SDK's device.ts.
+ * Duplicate here rather than import across RadarPluginContext boundary.
  *
  * @returns a newly generated UUID
  */

--- a/packages/autocomplete/src/version.ts
+++ b/packages/autocomplete/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.1.0';
+export default '1.1.1';

--- a/packages/autocomplete/test/autocomplete.test.ts
+++ b/packages/autocomplete/test/autocomplete.test.ts
@@ -1,0 +1,167 @@
+import fetchMock from 'jest-fetch-mock';
+
+import Radar from '../../../src';
+import AddressesAPI from '../../../src/api/addresses';
+import ConfigAPI from '../../../src/api/config';
+import ContextAPI from '../../../src/api/context';
+import ConversionsAPI from '../../../src/api/conversions';
+import GeocodingAPI from '../../../src/api/geocoding';
+import RoutingAPI from '../../../src/api/routing';
+import SearchAPI from '../../../src/api/search';
+import TrackAPI from '../../../src/api/track';
+import TripsAPI from '../../../src/api/trips';
+import Config from '../../../src/config';
+import Device from '../../../src/device';
+import Http from '../../../src/http';
+import Logger from '../../../src/logger';
+import Navigator from '../../../src/navigator';
+import Session from '../../../src/session';
+import Storage from '../../../src/storage';
+import AutocompleteUI from '../src/autocomplete';
+
+import type { RadarPluginContext } from 'radar-sdk-js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const REQUEST_ID = '01a01c2e-7512-704c-aa02-81253218d810';
+
+const addresses = [
+  { formattedAddress: '66 Steuben St, Brooklyn, NY 11205 USA', addressLabel: '66 Steuben St' },
+  { formattedAddress: '67 Steuben St, Brooklyn, NY 11205 USA', addressLabel: '67 Steuben St' },
+];
+
+// the real SDK modules, assembled the same way Radar.registerPlugin does. the cast bridges
+// the src-vs-dist declarations of RadarPluginContext; every value here is the real module.
+const ctx = {
+  Radar,
+  Config,
+  Http,
+  Storage,
+  Device,
+  Session,
+  Logger,
+  Navigator,
+  apis: {
+    Addresses: AddressesAPI,
+    Config: ConfigAPI,
+    Context: ContextAPI,
+    Conversions: ConversionsAPI,
+    Geocoding: GeocodingAPI,
+    Routing: RoutingAPI,
+    Search: SearchAPI,
+    Track: TrackAPI,
+    Trips: TripsAPI,
+  },
+} as unknown as RadarPluginContext;
+
+// respond to autocomplete calls with a request id header, and to click calls with a bare 204
+const mockAutocompleteApi = (requestId = REQUEST_ID) => {
+  fetchMock.mockResponse(async (req) => {
+    if (req.url.includes('/v1/config')) {
+      return JSON.stringify({});
+    }
+    if (req.url.includes('/search/autocomplete/click')) {
+      return { body: '', status: 204 };
+    }
+    return {
+      body: JSON.stringify({ meta: {}, addresses }),
+      status: 200,
+      headers: { 'x-radar-request-id': requestId },
+    };
+  });
+};
+
+const autocompleteRequests = () =>
+  fetchMock.mock.calls.filter(([url]) => String(url as string).includes('/search/autocomplete?'));
+
+const clickRequests = () =>
+  fetchMock.mock.calls.filter(([url]) => String(url as string).includes('/search/autocomplete/click'));
+
+const createWidget = () => new AutocompleteUI({ container: 'autocomplete' }, ctx);
+
+describe('AutocompleteUI sessions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="autocomplete"></div>';
+    Radar.initialize('prj_test_pk_123');
+    mockAutocompleteApi();
+  });
+
+  afterEach(() => {
+    Radar.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('sends a session token UUID on every autocomplete request', async () => {
+    const widget = createWidget();
+
+    await widget.fetchResults('66 steuben');
+
+    const url = new URL(String(autocompleteRequests()[0]![0] as string));
+    expect(url.searchParams.get('sessionToken')).toMatch(UUID_PATTERN);
+  });
+
+  it('reuses the same session token across requests', async () => {
+    const widget = createWidget();
+
+    await widget.fetchResults('66 steu');
+    await widget.fetchResults('66 steuben');
+
+    const tokens = autocompleteRequests().map(([url]) =>
+      new URL(String(url as string)).searchParams.get('sessionToken'),
+    );
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).toEqual(tokens[1]);
+  });
+
+  it('mints a distinct session token per widget', () => {
+    document.body.innerHTML = '<div id="autocomplete"></div><div id="autocomplete-2"></div>';
+
+    const first = new AutocompleteUI({ container: 'autocomplete' }, ctx);
+    const second = new AutocompleteUI({ container: 'autocomplete-2' }, ctx);
+
+    expect(first.sessionToken).not.toEqual(second.sessionToken);
+  });
+
+  it('reports a click with the session token, originating request id, and result index', async () => {
+    const widget = createWidget();
+
+    const results = await widget.fetchResults('66 steuben');
+    widget.displayResults(results);
+    widget.select(1);
+    await Promise.resolve();
+
+    const click = clickRequests()[0];
+    expect(click).toBeDefined();
+    expect(JSON.parse(click![1]!.body as string)).toEqual({
+      sessionToken: widget.sessionToken,
+      requestId: REQUEST_ID,
+      idx: 1,
+    });
+  });
+
+  it('reports the click against the most recent autocomplete response', async () => {
+    const widget = createWidget();
+
+    mockAutocompleteApi('01a01c2e-7512-704c-aa02-000000000001');
+    widget.displayResults(await widget.fetchResults('66 steu'));
+
+    mockAutocompleteApi('01a01c2e-7512-704c-aa02-000000000002');
+    widget.displayResults(await widget.fetchResults('66 steuben'));
+
+    widget.select(0);
+    await Promise.resolve();
+
+    const click = clickRequests()[0];
+    expect(JSON.parse(click![1]!.body as string).requestId).toEqual('01a01c2e-7512-704c-aa02-000000000002');
+  });
+
+  it('does not report a click when the selected index has no result', async () => {
+    const widget = createWidget();
+
+    widget.displayResults(await widget.fetchResults('66 steuben'));
+    widget.select(99);
+    await Promise.resolve();
+
+    expect(clickRequests()).toHaveLength(0);
+  });
+});

--- a/packages/autocomplete/test/autocomplete.test.ts
+++ b/packages/autocomplete/test/autocomplete.test.ts
@@ -19,7 +19,8 @@ import Session from '../../../src/session';
 import Storage from '../../../src/storage';
 import AutocompleteUI from '../src/autocomplete';
 
-import type { RadarPluginContext } from 'radar-sdk-js';
+import type { RadarPluginContext } from '../../../src/plugin';
+import type { RadarAutocompleteUIOptions } from '../src/types';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -30,10 +31,9 @@ const addresses = [
   { formattedAddress: '67 Steuben St, Brooklyn, NY 11205 USA', addressLabel: '67 Steuben St' },
 ];
 
-// the real SDK modules, assembled the same way Radar.registerPlugin does. the cast bridges
-// the src-vs-dist declarations of RadarPluginContext; every value here is the real module.
+// the real SDK modules, assembled the same way Radar.registerPlugin does.
 const ctx = {
-  Radar,
+  Radar: Radar as RadarPluginContext['Radar'],
   Config,
   Http,
   Storage,
@@ -52,7 +52,7 @@ const ctx = {
     Track: TrackAPI,
     Trips: TripsAPI,
   },
-} as unknown as RadarPluginContext;
+} satisfies RadarPluginContext;
 
 // respond to autocomplete calls with a request id header, and to click calls with a bare 204
 const mockAutocompleteApi = (requestId = REQUEST_ID) => {
@@ -77,7 +77,13 @@ const autocompleteRequests = () =>
 const clickRequests = () =>
   fetchMock.mock.calls.filter(([url]) => String(url as string).includes('/search/autocomplete/click'));
 
-const createWidget = () => new AutocompleteUI({ container: 'autocomplete' }, ctx);
+// `ctx as never` is the one unchecked point: AutocompleteUI's declared parameter resolves to
+// the dist-built RadarPluginContext, and classes with private members are nominally typed, so
+// the src-built ctx above is not assignable to it. every value in it is the real module.
+const mount = (options: Partial<RadarAutocompleteUIOptions> = {}) =>
+  new AutocompleteUI({ container: 'autocomplete', ...options }, ctx as never);
+
+const createWidget = () => mount();
 
 describe('AutocompleteUI sessions', () => {
   beforeEach(() => {
@@ -116,8 +122,8 @@ describe('AutocompleteUI sessions', () => {
   it('mints a distinct session token per widget', () => {
     document.body.innerHTML = '<div id="autocomplete"></div><div id="autocomplete-2"></div>';
 
-    const first = new AutocompleteUI({ container: 'autocomplete' }, ctx);
-    const second = new AutocompleteUI({ container: 'autocomplete-2' }, ctx);
+    const first = mount();
+    const second = mount({ container: 'autocomplete-2' });
 
     expect(first.sessionToken).not.toEqual(second.sessionToken);
   });
@@ -153,6 +159,58 @@ describe('AutocompleteUI sessions', () => {
 
     const click = clickRequests()[0];
     expect(JSON.parse(click![1]!.body as string).requestId).toEqual('01a01c2e-7512-704c-aa02-000000000002');
+  });
+
+  it('reports the click even when onSelection throws', async () => {
+    const widget = mount({
+      onSelection: () => {
+        throw new Error('consumer callback blew up');
+      },
+    });
+
+    widget.displayResults(await widget.fetchResults('66 steuben'));
+    expect(() => widget.select(0)).toThrow('consumer callback blew up');
+    await Promise.resolve();
+
+    expect(clickRequests()).toHaveLength(1);
+  });
+
+  it('does not report a click when the response carried no request id', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url.includes('/v1/config')) {
+        return JSON.stringify({});
+      }
+      if (req.url.includes('/search/autocomplete/click')) {
+        return { body: '', status: 204 };
+      }
+      // no x-radar-request-id header
+      return { body: JSON.stringify({ meta: {}, addresses }), status: 200 };
+    });
+    const widget = createWidget();
+
+    widget.displayResults(await widget.fetchResults('66 steuben'));
+    widget.select(0);
+    await Promise.resolve();
+
+    expect(clickRequests()).toHaveLength(0);
+  });
+
+  it("scopes each widget's requests to its own session token", async () => {
+    document.body.innerHTML = '<div id="autocomplete"></div><div id="autocomplete-2"></div>';
+    const first = mount();
+    const second = mount({ container: 'autocomplete-2' });
+
+    // serialized on purpose: both widgets share the 'autocomplete-ui' dedup key, so concurrent
+    // fetches abort each other. that behavior predates session association and is deliberately left
+    // alone, so this asserts only that session tokens do not leak between widgets.
+    await first.fetchResults('66 steu');
+    await second.fetchResults('120 fifth');
+
+    const tokens = autocompleteRequests().map(([url]) =>
+      new URL(String(url as string)).searchParams.get('sessionToken'),
+    );
+    expect(tokens).toEqual([first.sessionToken, second.sessionToken]);
+    expect(first.sessionToken).not.toEqual(second.sessionToken);
   });
 
   it('does not report a click when the selected index has no result', async () => {

--- a/packages/autocomplete/test/autocomplete.test.ts
+++ b/packages/autocomplete/test/autocomplete.test.ts
@@ -83,8 +83,6 @@ const clickRequests = () =>
 const mount = (options: Partial<RadarAutocompleteUIOptions> = {}) =>
   new AutocompleteUI({ container: 'autocomplete', ...options }, ctx as never);
 
-const createWidget = () => mount();
-
 describe('AutocompleteUI sessions', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="autocomplete"></div>';
@@ -98,7 +96,7 @@ describe('AutocompleteUI sessions', () => {
   });
 
   it('sends a session token UUID on every autocomplete request', async () => {
-    const widget = createWidget();
+    const widget = mount();
 
     await widget.fetchResults('66 steuben');
 
@@ -107,7 +105,7 @@ describe('AutocompleteUI sessions', () => {
   });
 
   it('reuses the same session token across requests', async () => {
-    const widget = createWidget();
+    const widget = mount();
 
     await widget.fetchResults('66 steu');
     await widget.fetchResults('66 steuben');
@@ -129,7 +127,7 @@ describe('AutocompleteUI sessions', () => {
   });
 
   it('reports a click with the session token, originating request id, and result index', async () => {
-    const widget = createWidget();
+    const widget = mount();
 
     const results = await widget.fetchResults('66 steuben');
     widget.displayResults(results);
@@ -146,7 +144,7 @@ describe('AutocompleteUI sessions', () => {
   });
 
   it('reports the click against the most recent autocomplete response', async () => {
-    const widget = createWidget();
+    const widget = mount();
 
     mockAutocompleteApi('01a01c2e-7512-704c-aa02-000000000001');
     widget.displayResults(await widget.fetchResults('66 steu'));
@@ -186,7 +184,7 @@ describe('AutocompleteUI sessions', () => {
       // no x-radar-request-id header
       return { body: JSON.stringify({ meta: {}, addresses }), status: 200 };
     });
-    const widget = createWidget();
+    const widget = mount();
 
     widget.displayResults(await widget.fetchResults('66 steuben'));
     widget.select(0);
@@ -214,7 +212,7 @@ describe('AutocompleteUI sessions', () => {
   });
 
   it('does not report a click when the selected index has no result', async () => {
-    const widget = createWidget();
+    const widget = mount();
 
     widget.displayResults(await widget.fetchResults('66 steuben'));
     widget.select(99);

--- a/packages/autocomplete/test/uuid.test.ts
+++ b/packages/autocomplete/test/uuid.test.ts
@@ -1,11 +1,45 @@
 import generateUUID from '../src/uuid';
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
 describe('generateUUID', () => {
   it('should return a v4 UUID', () => {
-    expect(generateUUID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(generateUUID()).toMatch(UUID_PATTERN);
   });
 
   it('should return a different UUID on each call', () => {
     expect(generateUUID()).not.toEqual(generateUUID());
+  });
+
+  describe('when crypto.randomUUID is available', () => {
+    const stubbed = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    beforeEach(() => {
+      Object.defineProperty(crypto, 'randomUUID', {
+        value: () => stubbed,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      delete (crypto as { randomUUID?: unknown }).randomUUID;
+    });
+
+    it('should delegate to it rather than the fallback', () => {
+      expect(generateUUID()).toEqual(stubbed);
+    });
+  });
+
+  describe('when crypto.randomUUID is unavailable', () => {
+    // insecure origins and older browsers expose getRandomValues but not randomUUID
+    it('should fall back to getRandomValues', () => {
+      expect('randomUUID' in crypto).toBe(false);
+      expect(generateUUID()).toMatch(UUID_PATTERN);
+    });
+
+    it('should still return a different UUID on each call', () => {
+      expect(generateUUID()).not.toEqual(generateUUID());
+    });
   });
 });

--- a/packages/autocomplete/test/uuid.test.ts
+++ b/packages/autocomplete/test/uuid.test.ts
@@ -1,0 +1,11 @@
+import generateUUID from '../src/uuid';
+
+describe('generateUUID', () => {
+  it('should return a v4 UUID', () => {
+    expect(generateUUID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('should return a different UUID on each call', () => {
+    expect(generateUUID()).not.toEqual(generateUUID());
+  });
+});

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -34,9 +34,7 @@ class SearchAPI {
       }
     }
 
-    const { data: response, requestId: radarRequestId } = await Http.request<
-      Omit<RadarAutocompleteResponse, 'response' | 'requestId'>
-    >({
+    const response = await Http.request<Omit<RadarAutocompleteResponse, 'response' | 'requestId'>>({
       method: 'GET',
       path: 'search/autocomplete',
       data: {
@@ -52,13 +50,12 @@ class SearchAPI {
         sessionToken,
       },
       requestId,
-      includeRequestId: true,
     });
 
     const autocompleteRes: RadarAutocompleteResponse = {
       addresses: response.addresses,
       // echoed back to search/autocomplete/click to attribute a selection to this response
-      requestId: radarRequestId,
+      requestId: response.meta?.requestId,
     };
 
     if (options.debug) {

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -76,7 +76,7 @@ class SearchAPI {
         method: 'POST',
         path: 'search/autocomplete/click',
         data: { sessionToken, requestId, idx },
-        // the selection often navigates the page; keepalive lets the report outlive it
+        // the selection may navigate the page; keepalive lets the report outlive it
         keepalive: true,
       });
     } catch (err) {

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,5 +1,6 @@
 import Config from '../config';
 import Http from '../http';
+import Logger from '../logger';
 import Navigator from '../navigator';
 
 import type {
@@ -78,9 +79,10 @@ class SearchAPI {
         // the selection often navigates the page; keepalive lets the report outlive it
         keepalive: true,
       });
-    } catch {
+    } catch (err) {
       // clickthroughs are fire-and-forget. an expired session or a network blip must never
-      // surface to the caller, and is never retried.
+      // surface to the caller, and is never retried
+      Logger.debug(`Autocomplete click not reported: ${String(err)}`);
     }
   }
 

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -3,6 +3,7 @@ import Http from '../http';
 import Navigator from '../navigator';
 
 import type {
+  RadarAutocompleteClickParams,
   RadarAutocompleteParams,
   RadarAutocompleteResponse,
   RadarSearchPlacesParams,
@@ -22,7 +23,7 @@ class SearchAPI {
   static async autocomplete(params: RadarAutocompleteParams, requestId?: string): Promise<RadarAutocompleteResponse> {
     const options = Config.get();
 
-    const { query, limit, layers, countryCode, expandUnits, mailable, lang, postalCode } = params;
+    const { query, limit, layers, countryCode, expandUnits, mailable, lang, postalCode, sessionToken } = params;
     let { near } = params;
 
     // near can be provided as a string or Location object
@@ -33,7 +34,9 @@ class SearchAPI {
       }
     }
 
-    const response = await Http.request<Omit<RadarAutocompleteResponse, 'response'>>({
+    const { data: response, requestId: radarRequestId } = await Http.request<
+      Omit<RadarAutocompleteResponse, 'response' | 'requestId'>
+    >({
       method: 'GET',
       path: 'search/autocomplete',
       data: {
@@ -46,12 +49,16 @@ class SearchAPI {
         mailable,
         lang,
         postalCode,
+        sessionToken,
       },
       requestId,
+      includeRequestId: true,
     });
 
     const autocompleteRes: RadarAutocompleteResponse = {
       addresses: response.addresses,
+      // echoed back to search/autocomplete/click to attribute a selection to this response
+      requestId: radarRequestId,
     };
 
     if (options.debug) {
@@ -59,6 +66,25 @@ class SearchAPI {
     }
 
     return autocompleteRes;
+  }
+
+  /**
+   * report a clickthrough on an autocomplete result
+   * @param params - session token, originating request ID, and result index
+   */
+  static async autocompleteClick({ sessionToken, requestId, idx }: RadarAutocompleteClickParams): Promise<void> {
+    try {
+      await Http.request({
+        method: 'POST',
+        path: 'search/autocomplete/click',
+        data: { sessionToken, requestId, idx },
+        // the selection often navigates the page; keepalive lets the report outlive it
+        keepalive: true,
+      });
+    } catch {
+      // clickthroughs are fire-and-forget. an expired session or a network blip must never
+      // surface to the caller, and is never retried.
+    }
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,10 @@ class Config {
   /** default option values applied during initialization */
   static defaultOptions = {
     live: false,
-    logLevel: 'error',
-    host: 'https://api.radar.io',
+    logLevel: 'debug',
+    host: 'https://api-server-dev-binh.use1.radar-staging.com',
     version: 'v1',
-    debug: false,
+    debug: true,
   };
 
   /** store SDK options (called by Radar.initialize) */

--- a/src/http.ts
+++ b/src/http.ts
@@ -58,8 +58,14 @@ interface HttpRequestOptions {
   headers?: Record<string, string>;
   responseType?: 'blob' | 'json';
   requestId?: string;
-  /** when true, the response is returned as `{ data, requestId }` with the `x-radar-request-id` header */
-  includeRequestId?: boolean;
+  /**
+   * when `true`, the response is returned as `{ data, requestId }` carrying the
+   * `x-radar-request-id` header. typed as the literal `true` rather than `boolean` on
+   * purpose: this flag selects the return shape, so it has to be statically known. a
+   * `boolean` variable would match the general overload and leave the caller statically
+   * holding the bare body while receiving the wrapper at runtime.
+   */
+  includeRequestId?: true;
   /** when true, the request survives a page unload (fire-and-forget beacons) */
   keepalive?: boolean;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -41,6 +41,13 @@ interface RadarBlobResponse {
 
 export type RadarResponse = RadarApiResponse | RadarBlobResponse;
 
+/** Response paired with the `x-radar-request-id` header, returned when `includeRequestId` is set */
+export interface RadarResponseWithRequestId<T> {
+  data: T;
+  /** the `x-radar-request-id` response header, when the server sent one */
+  requestId?: string;
+}
+
 /** Request configuration for Http.request */
 interface HttpRequestOptions {
   method: HttpMethod;
@@ -51,6 +58,10 @@ interface HttpRequestOptions {
   headers?: Record<string, string>;
   responseType?: 'blob' | 'json';
   requestId?: string;
+  /** when true, the response is returned as `{ data, requestId }` with the `x-radar-request-id` header */
+  includeRequestId?: boolean;
+  /** when true, the request survives a page unload (fire-and-forget beacons) */
+  keepalive?: boolean;
 }
 
 const inFlightRequests = new Map<string, AbortController>();
@@ -80,6 +91,9 @@ class Http {
    */
   static async request(options: HttpRequestOptions & { responseType: 'blob' }): Promise<RadarBlobResponse>;
   static async request<T extends Record<string, any> = RadarApiResponse>(
+    options: HttpRequestOptions & { includeRequestId: true },
+  ): Promise<RadarResponseWithRequestId<T & { meta?: RadarApiMeta }>>;
+  static async request<T extends Record<string, any> = RadarApiResponse>(
     options: HttpRequestOptions,
   ): Promise<T & { meta?: RadarApiMeta }>;
   static async request<T extends Record<string, any> = RadarApiResponse>({
@@ -91,7 +105,11 @@ class Http {
     headers = {},
     responseType,
     requestId,
-  }: HttpRequestOptions): Promise<(T & { meta?: RadarApiMeta }) | RadarBlobResponse> {
+    includeRequestId,
+    keepalive,
+  }: HttpRequestOptions): Promise<
+    (T & { meta?: RadarApiMeta }) | RadarBlobResponse | RadarResponseWithRequestId<T & { meta?: RadarApiMeta }>
+  > {
     const options = Config.get();
 
     const { publishableKey, authToken } = options;
@@ -144,6 +162,7 @@ class Http {
         method,
         headers: allHeaders,
         body,
+        keepalive,
         signal: abortController.signal,
       });
     } catch {
@@ -171,7 +190,10 @@ class Http {
       if (responseType === 'blob') {
         parsed = { code: response.status, data: await response.blob() };
       } else {
-        parsed = (await response.json()) as RadarApiResponse;
+        // some endpoints (e.g. search/autocomplete/click) reply 204 with no body,
+        // which response.json() would reject on
+        const text = await response.text();
+        parsed = (text ? JSON.parse(text) : {}) as RadarApiResponse;
       }
     } catch (err) {
       if (parsed) {
@@ -197,6 +219,12 @@ class Http {
     }
 
     if (response.ok) {
+      if (includeRequestId) {
+        return {
+          data: parsed as T,
+          requestId: response.headers.get('x-radar-request-id') ?? undefined,
+        };
+      }
       return parsed as T;
     }
     if (options.debug) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -24,6 +24,11 @@ interface RadarApiMeta {
   error?: string;
   message?: string;
   type?: string;
+  /**
+   * Attached from the `x-radar-request-id` response header
+   * For use when reporting an issue to Radar
+   */
+  requestId?: string;
 }
 
 /** Base shape all Radar API JSON responses share */
@@ -41,13 +46,6 @@ interface RadarBlobResponse {
 
 export type RadarResponse = RadarApiResponse | RadarBlobResponse;
 
-/** Response paired with the `x-radar-request-id` header, returned when `includeRequestId` is set */
-export interface RadarResponseWithRequestId<T> {
-  data: T;
-  /** the `x-radar-request-id` response header, when the server sent one */
-  requestId?: string;
-}
-
 /** Request configuration for Http.request */
 interface HttpRequestOptions {
   method: HttpMethod;
@@ -58,14 +56,6 @@ interface HttpRequestOptions {
   headers?: Record<string, string>;
   responseType?: 'blob' | 'json';
   requestId?: string;
-  /**
-   * when `true`, the response is returned as `{ data, requestId }` carrying the
-   * `x-radar-request-id` header. typed as the literal `true` rather than `boolean` on
-   * purpose: this flag selects the return shape, so it has to be statically known. a
-   * `boolean` variable would match the general overload and leave the caller statically
-   * holding the bare body while receiving the wrapper at runtime.
-   */
-  includeRequestId?: true;
   /** when true, the request survives a page unload (fire-and-forget beacons) */
   keepalive?: boolean;
 }
@@ -97,9 +87,6 @@ class Http {
    */
   static async request(options: HttpRequestOptions & { responseType: 'blob' }): Promise<RadarBlobResponse>;
   static async request<T extends Record<string, any> = RadarApiResponse>(
-    options: HttpRequestOptions & { includeRequestId: true },
-  ): Promise<RadarResponseWithRequestId<T & { meta?: RadarApiMeta }>>;
-  static async request<T extends Record<string, any> = RadarApiResponse>(
     options: HttpRequestOptions,
   ): Promise<T & { meta?: RadarApiMeta }>;
   static async request<T extends Record<string, any> = RadarApiResponse>({
@@ -111,11 +98,8 @@ class Http {
     headers = {},
     responseType,
     requestId,
-    includeRequestId,
     keepalive,
-  }: HttpRequestOptions): Promise<
-    (T & { meta?: RadarApiMeta }) | RadarBlobResponse | RadarResponseWithRequestId<T & { meta?: RadarApiMeta }>
-  > {
+  }: HttpRequestOptions): Promise<(T & { meta?: RadarApiMeta }) | RadarBlobResponse> {
     const options = Config.get();
 
     const { publishableKey, authToken } = options;
@@ -213,6 +197,16 @@ class Http {
       }
     }
 
+    // surface the request id on meta for every JSON response, success or failure. blob
+    // responses are skipped: RadarBlobResponse declares `meta?: undefined`.
+    if (responseType !== 'blob' && parsed && typeof parsed === 'object') {
+      const radarRequestId = response.headers.get('x-radar-request-id');
+      if (radarRequestId) {
+        const apiResponse = parsed as RadarApiResponse;
+        apiResponse.meta = { ...apiResponse.meta, requestId: radarRequestId };
+      }
+    }
+
     if (parsed && typeof parsed === 'object' && 'meta' in parsed) {
       const error = parsed.meta?.error;
       if (error === 'ERROR_PERMISSIONS') {
@@ -225,12 +219,6 @@ class Http {
     }
 
     if (response.ok) {
-      if (includeRequestId) {
-        return {
-          data: parsed as T,
-          requestId: response.headers.get('x-radar-request-id') ?? undefined,
-        };
-      }
       return parsed as T;
     }
     if (options.debug) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,11 +481,25 @@ export interface RadarAutocompleteParams {
   lang?: string;
   /** filter by postal code */
   postalCode?: string;
+  /** UUID grouping related autocomplete requests and their clickthrough into one session */
+  sessionToken?: string;
 }
 
 /** response from {@link Radar.autocomplete} */
 export interface RadarAutocompleteResponse extends RadarResponse {
   addresses: RadarAutocompleteAddress[];
+  /** the `x-radar-request-id` of the originating request, echoed back when reporting a click */
+  requestId?: string;
+}
+
+/** parameters for reporting an autocomplete clickthrough */
+export interface RadarAutocompleteClickParams {
+  /** the session UUID sent on the originating autocomplete request */
+  sessionToken: string;
+  /** the `x-radar-request-id` of the autocomplete response the selection came from */
+  requestId: string;
+  /** zero-based index of the selected result */
+  idx: number;
 }
 
 /** parameters for {@link Radar.searchPlaces} */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '5.1.1';
+export default '5.1.2';

--- a/test/api/search.test.ts
+++ b/test/api/search.test.ts
@@ -136,7 +136,6 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
-          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: undefined,
@@ -191,7 +190,6 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
-          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: `${latitude},${longitude}`,
@@ -218,7 +216,6 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
-          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: `${latitude},${longitude}`,

--- a/test/api/search.test.ts
+++ b/test/api/search.test.ts
@@ -151,7 +151,7 @@ describe('Search', () => {
       });
     });
 
-    describe('session tracking', () => {
+    describe('session association', () => {
       it('should pass sessionToken through to the autocomplete request', async () => {
         mockRequest(200, autocompleteResponse);
 

--- a/test/api/search.test.ts
+++ b/test/api/search.test.ts
@@ -1,10 +1,12 @@
+import fetchMock from 'jest-fetch-mock';
+
 import Radar from '../../src';
 import Search from '../../src/api/search';
 import Config from '../../src/config';
 import Http from '../../src/http';
 import Navigator from '../../src/navigator';
 import { latitude, longitude } from '../common';
-import { getResponseWithDebug, mockRequest } from '../utils';
+import { getRequest, getResponseWithDebug, mockRequest } from '../utils';
 
 import type { RadarGeocodeLayer, RadarOptions } from '../../src/types';
 
@@ -134,6 +136,7 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
+          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: undefined,
@@ -145,6 +148,33 @@ describe('Search', () => {
           },
         });
         expect(response).toEqual(validateResponse);
+      });
+    });
+
+    describe('session tracking', () => {
+      it('should pass sessionToken through to the autocomplete request', async () => {
+        mockRequest(200, autocompleteResponse);
+
+        await Search.autocomplete({ query, sessionToken: 'ffbcb2ca-1d1c-4f96-9b91-fd0b0b0e1b7f' });
+
+        expect(getRequest().url).toContain('sessionToken=ffbcb2ca-1d1c-4f96-9b91-fd0b0b0e1b7f');
+      });
+
+      it('should return the originating x-radar-request-id on the response', async () => {
+        fetchMock.mockResponse(async (req) => {
+          if (req.url.includes('/v1/config')) {
+            return JSON.stringify({});
+          }
+          return {
+            body: JSON.stringify(autocompleteResponse),
+            status: 200,
+            headers: { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
+          };
+        });
+
+        const response = await Search.autocomplete({ query });
+
+        expect(response.requestId).toEqual('01a01c2e-7512-704c-aa02-81253218d810');
       });
     });
 
@@ -161,6 +191,7 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
+          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: `${latitude},${longitude}`,
@@ -187,6 +218,7 @@ describe('Search', () => {
         expect(Http.request).toHaveBeenCalledWith({
           method: 'GET',
           path: 'search/autocomplete',
+          includeRequestId: true,
           data: {
             query: 'mock-query',
             near: `${latitude},${longitude}`,
@@ -199,6 +231,44 @@ describe('Search', () => {
         });
         expect(response).toEqual(validateResponse);
       });
+    });
+  });
+  describe('autocompleteClick', () => {
+    const sessionToken = 'ffbcb2ca-1d1c-4f96-9b91-fd0b0b0e1b7f';
+    const requestId = '01a01c2e-7512-704c-aa02-81253218d810';
+
+    it('should POST the session, request id, and result index', async () => {
+      mockRequest(204, '');
+
+      await Search.autocompleteClick({ sessionToken, requestId, idx: 2 });
+
+      const request = getRequest();
+      expect(request.method).toEqual('POST');
+      expect(request.url).toContain('/v1/search/autocomplete/click');
+      expect(JSON.parse(request.body!)).toEqual({ sessionToken, requestId, idx: 2 });
+    });
+
+    it('should send the click with keepalive so it survives page navigation', async () => {
+      mockRequest(204, '');
+
+      await Search.autocompleteClick({ sessionToken, requestId, idx: 0 });
+
+      const lastCall = [...fetchMock.mock.calls]
+        .reverse()
+        .find(([url]) => String(url as string).includes('/autocomplete/click'));
+      expect(lastCall?.[1]?.keepalive).toBe(true);
+    });
+
+    it('should resolve without throwing when the session is unknown or expired', async () => {
+      mockRequest(400, { meta: { code: 400 } });
+
+      await expect(Search.autocompleteClick({ sessionToken, requestId, idx: 0 })).resolves.toBeUndefined();
+    });
+
+    it('should resolve without throwing on a network error', async () => {
+      fetchMock.mockReject(new TypeError('Network error'));
+
+      await expect(Search.autocompleteClick({ sessionToken, requestId, idx: 0 })).resolves.toBeUndefined();
     });
   });
 });

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -4,7 +4,7 @@ import Radar from '../src';
 import Config from '../src/config';
 import Http from '../src/http';
 import SDK_VERSION from '../src/version';
-import { getRequest, mockNetworkError, mockRequest } from './utils';
+import { getRequest, mockNetworkError, mockRequest, mockRequestWithHeaders } from './utils';
 
 describe('Http', () => {
   const publishableKey = 'prj_test_pk_123';
@@ -55,57 +55,53 @@ describe('Http', () => {
         expect(response).toEqual({});
       });
 
-      it('should return the x-radar-request-id header when includeRequestId is set', async () => {
-        fetchMock.mockResponse(async (req) => {
-          if (req.url.includes('/v1/config')) {
-            return JSON.stringify({});
-          }
-          return {
-            body: JSON.stringify(successResponse),
-            status: 200,
-            headers: { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
-          };
-        });
-
-        const { data, requestId } = await Http.request({ ...httpRequestParams, includeRequestId: true });
-
-        expect(requestId).toEqual('01a01c2e-7512-704c-aa02-81253218d810');
-        expect(data.code).toEqual(200);
-      });
-
-      it('should not wrap the response when includeRequestId is not set', async () => {
-        fetchMock.mockResponse(async (req) => {
-          if (req.url.includes('/v1/config')) {
-            return JSON.stringify({});
-          }
-          return {
-            body: JSON.stringify(successResponse),
-            status: 200,
-            headers: { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
-          };
+      it('should attach the x-radar-request-id header to meta', async () => {
+        mockRequestWithHeaders(200, successResponse, {
+          'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810',
         });
 
         const response = await Http.request(httpRequestParams);
 
-        expect(response).toEqual(successResponse);
+        expect(response.meta?.requestId).toEqual('01a01c2e-7512-704c-aa02-81253218d810');
+        expect(response.code).toEqual(200);
       });
 
-      it('should require includeRequestId to be the literal true, not a boolean', () => {
-        // a call expression, not `const x: boolean = true` -- the latter is narrowed back to
-        // the literal `true` by control-flow analysis and would not exercise anything
-        const dynamicFlag = (): boolean => true;
+      it('should not invent a requestId when the server sent no such header', async () => {
+        mockRequest(200, successResponse);
 
-        // compile-time assertion only -- never invoked. includeRequestId selects the return
-        // shape, so it must be statically known: a boolean variable would leave the caller
-        // statically holding the bare body while receiving { data, requestId } at runtime.
-        // if the option type ever widens back to `boolean`, the unused @ts-expect-error
-        // below becomes a compile error and this suite fails.
-        const neverCalled = async () => {
-          // @ts-expect-error includeRequestId must be `true`, not `boolean`
-          await Http.request({ ...httpRequestParams, includeRequestId: dynamicFlag() });
-        };
+        const response = await Http.request(httpRequestParams);
 
-        expect(neverCalled).toBeInstanceOf(Function);
+        expect(response.meta?.requestId).toBeUndefined();
+      });
+
+      it('should preserve server-sent meta fields alongside the requestId', async () => {
+        mockRequestWithHeaders(
+          200,
+          { ...successResponse, meta: { message: 'ok' } },
+          { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
+        );
+
+        const response = await Http.request(httpRequestParams);
+
+        expect(response.meta).toEqual({
+          message: 'ok',
+          requestId: '01a01c2e-7512-704c-aa02-81253218d810',
+        });
+      });
+
+      it('should attach the requestId to the response carried by a thrown error', async () => {
+        mockRequestWithHeaders(
+          400,
+          { meta: { message: 'bad' } },
+          {
+            'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810',
+          },
+        );
+
+        const err = await Http.request(httpRequestParams).catch((e) => e);
+
+        expect(err.status).toEqual('ERROR_BAD_REQUEST');
+        expect(err.response?.meta?.requestId).toEqual('01a01c2e-7512-704c-aa02-81253218d810');
       });
 
       it('should pass keepalive through to fetch so requests survive page unload', async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -90,6 +90,24 @@ describe('Http', () => {
         expect(response).toEqual(successResponse);
       });
 
+      it('should require includeRequestId to be the literal true, not a boolean', () => {
+        // a call expression, not `const x: boolean = true` -- the latter is narrowed back to
+        // the literal `true` by control-flow analysis and would not exercise anything
+        const dynamicFlag = (): boolean => true;
+
+        // compile-time assertion only -- never invoked. includeRequestId selects the return
+        // shape, so it must be statically known: a boolean variable would leave the caller
+        // statically holding the bare body while receiving { data, requestId } at runtime.
+        // if the option type ever widens back to `boolean`, the unused @ts-expect-error
+        // below becomes a compile error and this suite fails.
+        const neverCalled = async () => {
+          // @ts-expect-error includeRequestId must be `true`, not `boolean`
+          await Http.request({ ...httpRequestParams, includeRequestId: dynamicFlag() });
+        };
+
+        expect(neverCalled).toBeInstanceOf(Function);
+      });
+
       it('should pass keepalive through to fetch so requests survive page unload', async () => {
         mockRequest(200, successResponse);
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -42,6 +42,65 @@ describe('Http', () => {
         expect(response.code).toEqual(200);
       });
 
+      it('should resolve with an empty object on a 204 with no body', async () => {
+        fetchMock.mockResponse(async (req) => {
+          if (req.url.includes('/v1/config')) {
+            return JSON.stringify({});
+          }
+          return { body: '', status: 204 };
+        });
+
+        const response = await Http.request({ method: 'POST', path: 'search/autocomplete/click' });
+
+        expect(response).toEqual({});
+      });
+
+      it('should return the x-radar-request-id header when includeRequestId is set', async () => {
+        fetchMock.mockResponse(async (req) => {
+          if (req.url.includes('/v1/config')) {
+            return JSON.stringify({});
+          }
+          return {
+            body: JSON.stringify(successResponse),
+            status: 200,
+            headers: { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
+          };
+        });
+
+        const { data, requestId } = await Http.request({ ...httpRequestParams, includeRequestId: true });
+
+        expect(requestId).toEqual('01a01c2e-7512-704c-aa02-81253218d810');
+        expect(data.code).toEqual(200);
+      });
+
+      it('should not wrap the response when includeRequestId is not set', async () => {
+        fetchMock.mockResponse(async (req) => {
+          if (req.url.includes('/v1/config')) {
+            return JSON.stringify({});
+          }
+          return {
+            body: JSON.stringify(successResponse),
+            status: 200,
+            headers: { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
+          };
+        });
+
+        const response = await Http.request(httpRequestParams);
+
+        expect(response).toEqual(successResponse);
+      });
+
+      it('should pass keepalive through to fetch so requests survive page unload', async () => {
+        mockRequest(200, successResponse);
+
+        await Http.request({ ...httpRequestParams, keepalive: true });
+
+        const calls = fetchMock.mock.calls;
+        const lastCall = [...calls].reverse().find(([reqUrl]) => !String(reqUrl as string).includes('/v1/config'));
+
+        expect(lastCall?.[1]?.keepalive).toBe(true);
+      });
+
       it('should filter out undefined values in data', async () => {
         mockRequest(200, successResponse);
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -4,7 +4,7 @@ import Radar from '../src';
 import Config from '../src/config';
 import Http from '../src/http';
 import SDK_VERSION from '../src/version';
-import { getRequest, mockNetworkError, mockRequest, mockRequestWithHeaders } from './utils';
+import { getRequest, mockNetworkError, mockRequest } from './utils';
 
 describe('Http', () => {
   const publishableKey = 'prj_test_pk_123';
@@ -56,7 +56,7 @@ describe('Http', () => {
       });
 
       it('should attach the x-radar-request-id header to meta', async () => {
-        mockRequestWithHeaders(200, successResponse, {
+        mockRequest(200, successResponse, {
           'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810',
         });
 
@@ -75,7 +75,7 @@ describe('Http', () => {
       });
 
       it('should preserve server-sent meta fields alongside the requestId', async () => {
-        mockRequestWithHeaders(
+        mockRequest(
           200,
           { ...successResponse, meta: { message: 'ok' } },
           { 'x-radar-request-id': '01a01c2e-7512-704c-aa02-81253218d810' },
@@ -90,7 +90,7 @@ describe('Http', () => {
       });
 
       it('should attach the requestId to the response carried by a thrown error', async () => {
-        mockRequestWithHeaders(
+        mockRequest(
           400,
           { meta: { message: 'bad' } },
           {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -58,6 +58,16 @@ export const mockRequest = (status: number, response: unknown) => {
   });
 };
 
+// same as mockRequest, but with response headers (e.g. x-radar-request-id)
+export const mockRequestWithHeaders = (status: number, response: unknown, headers: Record<string, string>) => {
+  fetchMock.mockResponse(async (req) => {
+    if (req.url.includes('/v1/config')) {
+      return JSON.stringify({});
+    }
+    return { body: JSON.stringify(response), status: status || 200, headers };
+  });
+};
+
 export const getRequest = () => {
   // find the last non-config fetch call
   const calls = fetchMock.mock.calls;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,17 +49,8 @@ export const enableLocation = (position: NavigatorPosition, callback?: (args: an
 
 // mock a single API response — config calls are handled by the default
 // handler in globals.ts, so this only needs to cover the test request.
-export const mockRequest = (status: number, response: unknown) => {
-  fetchMock.mockResponse(async (req) => {
-    if (req.url.includes('/v1/config')) {
-      return JSON.stringify({});
-    }
-    return { body: JSON.stringify(response), status: status || 200 };
-  });
-};
-
-// same as mockRequest, but with response headers (e.g. x-radar-request-id)
-export const mockRequestWithHeaders = (status: number, response: unknown, headers: Record<string, string>) => {
+// pass `headers` to mock response headers such as x-radar-request-id.
+export const mockRequest = (status: number, response: unknown, headers?: Record<string, string>) => {
   fetchMock.mockResponse(async (req) => {
     if (req.url.includes('/v1/config')) {
       return JSON.stringify({});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "noUnusedLocals": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    // mirrors the jest moduleNameMapper so plugin sources typecheck without a build
+    "paths": {
+      "radar-sdk-js": ["./src/index.ts"]
+    }
   },
   "include": ["src/**/*", "test/**/*"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,7 +5,9 @@
     "noUnusedLocals": false,
     "resolveJsonModule": true,
     "baseUrl": ".",
-    // mirrors the jest moduleNameMapper so plugin sources typecheck without a build
+    // Same remap as jest's moduleNameMapper, but for the typechecker rather than the
+    // module loader: without it, plugin sources fail to resolve 'radar-sdk-js' types
+    // until dist/ has been built.
     "paths": {
       "radar-sdk-js": ["./src/index.ts"]
     }


### PR DESCRIPTION
- Adds AutocompleteUI support for autocomplete session creation and clickthrough events
- Adds `requestId` to `RadarApiMeta` object, for easier CS debugging flows

### QA
/autocomplete calls include `sessionToken`:
<img width="878" height="613" alt="Screenshot 2026-08-24 at 1 19 44 PM" src="https://github.com/user-attachments/assets/910fdd8d-9141-4599-8436-d3eccbec8398" />

click event sends /click request:
<img width="869" height="620" alt="Screenshot 2026-08-24 at 1 19 35 PM" src="https://github.com/user-attachments/assets/97668c45-67b4-4925-83e8-59e7a4c1725a" />


20th /click event returns 429, and debug logs, but does not disrupt client functionality:
<img width="844" height="637" alt="Screenshot 2026-08-24 at 1 19 04 PM" src="https://github.com/user-attachments/assets/cfa3dbd3-8033-4355-8a1e-ff94a1a6ca54" />
