### PR TITLE
MAPS-2581: Fixing config on SDK

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,10 @@ class Config {
   /** default option values applied during initialization */
   static defaultOptions = {
     live: false,
-    logLevel: 'debug',
-    host: 'https://api-server-dev-binh.use1.radar-staging.com',
+    logLevel: 'error',
+    host: 'https://api.radar.io',
     version: 'v1',
-    debug: true,
+    debug: false,
   };
 
   /** store SDK options (called by Radar.initialize) */


### PR DESCRIPTION
Fixing the host and log level setup on the SDK which came from a prior commit (had testing vars).